### PR TITLE
GatewayReceivers should only close servers when they are done receiving all pending chunks

### DIFF
--- a/skylark/gateway/gateway_sender.py
+++ b/skylark/gateway/gateway_sender.py
@@ -91,7 +91,7 @@ class GatewaySender:
         # close destination sockets
         for dst_socket in self.destination_sockets.values():
             dst_socket.close()
-        
+
         # wait for all chunks to reach state "downloaded"
         def wait_for_chunks(chunk_ids):
             cr_status = {}
@@ -102,7 +102,7 @@ class GatewaySender:
                 for chunk_id in chunk_ids:
                     cr_status[chunk_id] = host_state[chunk_id]["state"]
             return all(cr_status[chunk_id] == "downloaded" for chunk_id in chunk_ids)
-        
+
         wait_for(partial(wait_for_chunks, chunk_ids_to_send))
 
         # close servers

--- a/skylark/utils/utils.py
+++ b/skylark/utils/utils.py
@@ -28,7 +28,7 @@ class Timer:
         return self.end - self.start
 
 
-def wait_for(fn, timeout=60, interval=.25, progress_bar=False, desc="Waiting", leave_pbar=True):
+def wait_for(fn, timeout=60, interval=0.25, progress_bar=False, desc="Waiting", leave_pbar=True):
     # wait for fn to return True
     start = time.time()
     if progress_bar:


### PR DESCRIPTION
There was a small bug where GatewayReceivers would close a server during a pending transfer as the server sent data but the receiver hadn't started downloading it yet.