### PR TITLE
Working GCP in gateway

### DIFF
--- a/skylark/cli/cli.py
+++ b/skylark/cli/cli.py
@@ -87,7 +87,7 @@ def replicate_random(
     gcp_project: str = "skylark-333700",
     gateway_docker_image: str = os.environ.get("SKYLARK_DOCKER_IMAGE", "ghcr.io/parasj/skylark:main"),
     aws_instance_class: str = "m5.8xlarge",
-    gcp_instance_class: Optional[str] = None,
+    gcp_instance_class: Optional[str] = "n2-highmem-4",
     gcp_use_premium_network: bool = False,
     key_prefix: str = "/test/replicate_random",
     time_limit_seconds: Optional[int] = None,

--- a/skylark/compute/gcp/gcp_server.py
+++ b/skylark/compute/gcp/gcp_server.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import googleapiclient.discovery
 import paramiko
+from loguru import logger
 
 from skylark import key_root
 from skylark.compute.server import Server, ServerState
@@ -28,7 +29,7 @@ class GCPServer(Server):
         key_root = Path(key_root)
         key_root.mkdir(parents=True, exist_ok=True)
         if ssh_private_key is None:
-            self.ssh_private_key = key_root / f"gcp.pem"
+            self.ssh_private_key = key_root / f"gcp-cert.pem"
         else:
             self.ssh_private_key = ssh_private_key
 
@@ -88,7 +89,7 @@ class GCPServer(Server):
 
     def terminate_instance_impl(self):
         compute = self.get_gcp_client()
-        compute.instances().delete(project=self.gcp_project, zone=self.gcp_region, instance=self.instance_name).execute()
+        compute.instances().delete(project=self.gcp_project, zone=self.gcp_region, instance=self.instance_name()).execute()
 
     def get_ssh_client_impl(self, uname=os.environ.get("USER"), ssh_key_password="skylark"):
         """Return paramiko client that connects to this instance."""

--- a/skylark/replicate/replicator_client.py
+++ b/skylark/replicate/replicator_client.py
@@ -174,8 +174,8 @@ class ReplicatorClient:
         # assert all(len(path) == 2 for path in self.bound_paths), f"Only two-hop replication is supported"
 
         # todo support GCP
-        assert job.source_region.split(":")[0] == "aws", f"Only AWS is supported for now, got {job.source_region}"
-        assert job.dest_region.split(":")[0] == "aws", f"Only AWS is supported for now, got {job.dest_region}"
+        assert job.source_region.split(":")[0] in ["aws", "gcp"], f"Only AWS and GCP is supported for now, got {job.source_region}"
+        assert job.dest_region.split(":")[0] in ["aws", "gcp"], f"Only AWS and GCP is supported for now, got {job.dest_region}"
 
         # make list of chunks
         chunks = []


### PR DESCRIPTION
A very simple PR that enables GCP support for the Gateway

To test:
```
$ source scripts/pack_docker.sh; skylark replicate-random aws:ap-northeast-1 gcp:us-central1-a --chunk-size-mb 8 --n-chunks 1024 --num-gateways 1 --num-outgoing-connections 64

=================================================
  ______  _             _                 _
 / _____)| |           | |               | |
( (____  | |  _  _   _ | |  _____   ____ | |  _
 \____ \ | |_/ )| | | || | (____ | / ___)| |_/ )
 _____) )|  _ ( | |_| || | / ___ || |    |  _ (
(______/ |_| \_) \__  | \_)\_____||_|    |_| \_)
                (____/
=================================================

            __exit__:24  | Cloud SSH key initialization: 6.46s
    replicate_random:118 | Instances will remain up and may result in continued cloud billing. Remember to call `skylark deprovision` to deprovision gateways.
      wait_for_ready:138 | Waiting for skylark-333700:gcp:us-central1-a:skylark-gcp-3e2f0698a55b478b9bb14208516cedf3 to be ready
      wait_for_ready:138 | Waiting for aws:ap-northeast-1:i-0e2d9e5b41994c304 to be ready
      wait_for_ready:140 | skylark-333700:gcp:us-central1-a:skylark-gcp-3e2f0698a55b478b9bb14208516cedf3 is ready
      wait_for_ready:140 | aws:ap-northeast-1:i-0e2d9e5b41994c304 is ready
            __exit__:24  | Provisioning instances and waiting to boot: 58.73s
       start_gateway:184 | Starting gateway aws:ap-northeast-1:i-0e2d9e5b41994c304: Installing docker
       start_gateway:184 | Starting gateway skylark-333700:gcp:us-central1-a:skylark-gcp-3e2f0698a55b478b9bb14208516cedf3: Installing docker
       start_gateway:208 | Starting gateway aws:ap-northeast-1:i-0e2d9e5b41994c304: Starting monitoring
       start_gateway:208 | Starting gateway skylark-333700:gcp:us-central1-a:skylark-gcp-3e2f0698a55b478b9bb14208516cedf3: Starting monitoring
       start_gateway:213 | Starting gateway skylark-333700:gcp:us-central1-a:skylark-gcp-3e2f0698a55b478b9bb14208516cedf3: Pulling docker image
       start_gateway:218 | Starting gateway skylark-333700:gcp:us-central1-a:skylark-gcp-3e2f0698a55b478b9bb14208516cedf3: Starting gateway container ghcr.io/parasj/skylark:local-4c0221b9868e0ee1adc4e9cbda577f7f
^[[C^[[C^[[       start_gateway:213 | Starting gateway aws:ap-northeast-1:i-0e2d9e5b41994c304: Pulling docker image
       start_gateway:218 | Starting gateway aws:ap-northeast-1:i-0e2d9e5b41994c304: Starting gateway container ghcr.io/parasj/skylark:local-4c0221b9868e0ee1adc4e9cbda577f7f
            __exit__:24  | Install gateway package on instances: 91.66s
    replicate_random:126 | Provisioned path aws:ap-northeast-1 -> gcp:us-central1-a
    replicate_random:128 | 	[aws:ap-northeast-1] http://13.115.242.234:8888/container/f5a3baccbe3f
    replicate_random:128 | 	[gcp:us-central1-a] http://35.206.81.151:8888/container/88ca16d2bad1
            __exit__:24  | Building chunk requests: 0.01s
 send_chunk_requests:241 | Sending 1024 chunk requests to 13.115.242.234
            __exit__:24  | Dispatch chunk requests: 2.19s
    replicate_random:141 | 8.00GByte replication job launched
    monitor_transfer:286 | Web dashboard running at http://54.92.213.136:8080
    monitor_transfer:330 | 35/1024 chunks done (0.27 / 8.00GB, 0.43Gbit/s, ETA=144s)
    monitor_transfer:330 | 285/1024 chunks done (2.23 / 8.00GB, 0.81Gbit/s, ETA=56s)

{"total_runtime_s": 23.721418, "throughput_gbits": 2.697983737734397, "monitor_status": "completed", "success": true}
```