### PR TITLE
Cache public IPs

### DIFF
--- a/skylark/compute/azure/azure_server.py
+++ b/skylark/compute/azure/azure_server.py
@@ -11,6 +11,7 @@ import paramiko
 
 from skylark import key_root
 from skylark.compute.server import Server, ServerState
+from skylark.utils.cache import ignore_lru_cache
 from skylark.utils.utils import PathLike
 
 
@@ -107,10 +108,8 @@ class AzureServer(Server):
                 return ServerState.from_azure_state(status.code)
         return ServerState.UNKNOWN
 
+    @ignore_lru_cache()
     def public_ip(self):
-        if self.cached_public_ip_address is not None:
-            return self.cached_public_ip_address
-
         credential = DefaultAzureCredential()
         network_client = NetworkManagementClient(credential, self.subscription_id)
         public_ip = network_client.public_ip_addresses.get(self.name, AzureServer.ip_name(self.name))
@@ -118,10 +117,9 @@ class AzureServer(Server):
         # Sanity checks
         assert public_ip.location == self.location
         assert public_ip.name == AzureServer.ip_name(self.name)
-
-        self.cached_public_ip_address = public_ip.ip_address
         return public_ip.ip_address
 
+    @ignore_lru_cache()
     def instance_class(self):
         vm = self.get_virtual_machine()
         return vm.hardware_profile.vm_size
@@ -132,6 +130,7 @@ class AzureServer(Server):
     def instance_name(self):
         return self.name
 
+    @ignore_lru_cache()
     def tags(self):
         resource_group = self.get_resource_group()
         return resource_group.tags

--- a/skylark/compute/gcp/gcp_server.py
+++ b/skylark/compute/gcp/gcp_server.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from skylark import key_root
 from skylark.compute.server import Server, ServerState
+from skylark.utils.cache import ignore_lru_cache
 from skylark.utils.utils import PathLike
 
 
@@ -60,10 +61,12 @@ class GCPServer(Server):
     def get_instance_property(self, prop):
         return self.get_gcp_instance()[prop]
 
+    @ignore_lru_cache()
     def public_ip(self):
         """Get public IP for instance with GCP client"""
         return self.get_instance_property("networkInterfaces")[0]["accessConfigs"][0].get("natIP")
 
+    @ignore_lru_cache()
     def instance_class(self):
         return self.get_instance_property("machineType").split("/")[-1]
 
@@ -73,13 +76,16 @@ class GCPServer(Server):
     def instance_state(self):
         return ServerState.from_gcp_state(self.get_instance_property("status"))
 
+    @ignore_lru_cache()
     def instance_name(self):
         return self.get_instance_property("name")
 
+    @ignore_lru_cache()
     def tags(self):
         """Get labels for instance."""
         return self.get_instance_property("labels")
 
+    @ignore_lru_cache()
     def network_tier(self):
         interface = self.get_instance_property("networkInterfaces")[0]
         return interface["accessConfigs"][0]["networkTier"]


### PR DESCRIPTION
Querying for public IP addresses leads to significant slowdowns in some cases. In this PR, I cache public IPs in replicator_client.