### PR TITLE
Integrate `skylark replicate-json` CLI command with object stores 

### DIFF
--- a/skylark/cli/cli.py
+++ b/skylark/cli/cli.py
@@ -193,7 +193,7 @@ def replicate_json(
     size_total_mb: int = typer.Option(2048, "--size-total-mb", "-s", help="Total transfer size in MB (across n_chunks chunks)"),
     n_chunks: int = 512,
     # bucket options
-    use_random_data: bool = typer.Option(False, "--random-data", help="Use random data"),
+    use_random_data: False, 
     bucket_prefix: str = "skylark",
     source_bucket: str = typer.Option(None, "--source-bucket", help="Source bucket url"),
     dest_bucket: str = typer.Option(None, "--dest-bucket", help="Destination bucket url"),
@@ -204,7 +204,7 @@ def replicate_json(
     # cloud provider specific options
     azure_subscription: Optional[str] = None,
     gcp_project: Optional[str] = None,
-    aws_instance_class: str = "m5.4xlarge",
+    aws_instance_class: str = "m5.8xlarge",
     azure_instance_class: str = "Standard_D32_v5",
     gcp_instance_class: Optional[str] = "n2-standard-32",
     gcp_use_premium_network: bool = True,

--- a/skylark/compute/aws/aws_cloud_provider.py
+++ b/skylark/compute/aws/aws_cloud_provider.py
@@ -245,7 +245,6 @@ class AWSCloudProvider(CloudProvider):
         # catch botocore.exceptions.ClientError: "An error occurred (RequestLimitExceeded) when calling the RunInstances operation (reached max retries: 4): Request limit exceeded." and retry
         for i in range(4):
             try:
-                print("region", region)
                 instance = ec2.create_instances(
                     ImageId=self.get_ubuntu_ami_id(region),
                     InstanceType=instance_class,
@@ -275,7 +274,6 @@ class AWSCloudProvider(CloudProvider):
                     ],
                 )
             except botocore.exceptions.ClientError as e:
-                print("error region", region)
                 if not "RequestLimitExceeded" in str(e):
                     raise e
                 else:

--- a/skylark/test/test_replicator_client.py
+++ b/skylark/test/test_replicator_client.py
@@ -9,7 +9,7 @@ import concurrent
 import os
 from skylark.obj_store.s3_interface import S3Interface
 from skylark.obj_store.gcs_interface import GCSInterface
-#from skylark.obj_store.azure_interface import AzureInterface
+from skylark.obj_store.azure_interface import AzureInterface
 
 import tempfile
 import concurrent


### PR DESCRIPTION
Used the `test_replicator_client.py` script to generate and upload data to buckets, then transferred to a bucket in another region. 

**Note: GCP performance is very poor, because it takes a long while before it starts to send chunks.** 

### AWS 
Test command: 
```
skylark solver solve-throughput aws:us-east-1 aws:us-west-1 1 -o data/plan.json -o data/plan.json --max-instances 1;

skylark replicate-json data/plan.json \
--gcp-project skylark-sarah \
--source-bucket sarah-skylark-us-east-1 \
--dest-bucket sarah-skylark-us-west-1  \
--key-prefix test/direct_replication
```
Result: 
```
0/512 chunks done (0.00 / 2.00GB, 0.00Gbit/s, ETA=unknown)
81/512 chunks done (0.32 / 2.00GB, 0.60Gbit/s, ETA=22s)
287/512 chunks done (1.12 / 2.00GB, 1.42Gbit/s, ETA=4s)
---- 
{"total_runtime_s": 8.038048, "throughput_gbits": 1.9905330249334168, "monitor_status": "completed", "success": true}
```
### GCP 
```
skylark solver solve-throughput gcp:us-west1-a gcp:us-east1-b 1 -o data/plan.json -o data/plan.json --max-instances 1;

skylark replicate-json data/plan.json \
--gcp-project skylark-sarah \
--source-bucket sarah-skylark-us-west1-a \
--dest-bucket sarah-skylark-us-east1-b  \
--key-prefix test/direct_replication
```
Result: 
```
0/512 chunks done (0.00 / 2.00GB, 0.00Gbit/s, ETA=unknown)
0/512 chunks done (0.00 / 2.00GB, 0.00Gbit/s, ETA=unknown)
0/512 chunks done (0.00 / 2.00GB, 0.00Gbit/s, ETA=unknown)
0/512 chunks done (0.00 / 2.00GB, 0.00Gbit/s, ETA=unknown)
73/512 chunks done (0.29 / 2.00GB, 0.05Gbit/s, ETA=269s)
401/512 chunks done (1.57 / 2.00GB, 0.27Gbit/s, ETA=12s)
--- 
{"total_runtime_s": 62.859771, "throughput_gbits": 0.2545348120978678, "monitor_status": "completed", "success": true}
```

## Remaining TODOs

- [ ] Determine object keys dynamically (currently hardcoded with `n_chunks`)
- [ ] Specify object store directory to replicate 
- [ ] Determine `n_chunks` dynamically from object store directory 
- [ ] Test/support Azure 
- [ ] Separate script to generate/upload data 