### PR TITLE
Use a single resource group for all Azure resources

### DIFF
--- a/skylark/cli/cli_aws.py
+++ b/skylark/cli/cli_aws.py
@@ -135,7 +135,7 @@ def cp_datasync(src_bucket: str, dst_bucket: str, path: str):
             }
             typer.secho(f"{int(t.elapsed)}s\tStatus: {last_status}, {metadata}", fg="green")
             time.sleep(5)
-            if ((int(t.elapsed) > 300) and last_status == "LAUNCHING"):
+            if (int(t.elapsed) > 300) and last_status == "LAUNCHING":
                 typer.secho(
                     "The process might have errored out. One way to solve this is to delete the objects if they exist already, and restart the transfer",
                     fg="red",

--- a/skylark/compute/azure/azure_cloud_provider.py
+++ b/skylark/compute/azure/azure_cloud_provider.py
@@ -263,18 +263,18 @@ class AzureCloudProvider(CloudProvider):
 
     def get_instance_list(self, region: str) -> List[AzureServer]:
         credential = self.credential
-        resource_client = ResourceManagementClient(credential, self.subscription_id)
-        resource_group_list_iterator = resource_client.resource_groups.list(filter="tagName eq 'skylark' and tagValue eq 'true'")
+        compute_client = ComputeManagementClient(credential, self.subscription_id)
 
         server_list = []
-        for resource_group in resource_group_list_iterator:
-            if resource_group.location == region:
-                s = AzureServer(self.subscription_id, resource_group.name)
+        for vm in compute_client.virtual_machines.list(AzureServer.resource_group_name):
+            if vm.tags.get("skylark", None) == "true" and AzureServer.is_valid_vm_name(vm.name) and vm.location == region:
+                name = AzureServer.base_name_from_vm_name(vm.name)
+                s = AzureServer(self.subscription_id, name)
                 if s.is_valid():
                     server_list.append(s)
                 else:
                     logger.warning(
-                        f"Warning: malformed Azure resource group {resource_group.name} found and ignored. You should go to the Microsoft Azure portal, investigate this manually, and delete any orphaned resources that may be allocated."
+                        f"Warning: malformed Azure instance {name} found and ignored. You should go to the Microsoft Azure portal, investigate this manually, and delete any orphaned resources that may be allocated."
                     )
         return server_list
 
@@ -287,6 +287,29 @@ class AzureCloudProvider(CloudProvider):
             key.write_private_key_file(self.private_key_path, password="skylark")
             with open(self.public_key_path, "w") as f:
                 f.write(f"{key.get_name()} {key.get_base64()}\n")
+
+    def set_up_resource_group(self, clean_up_orphans=True):
+        credential = self.credential
+        resource_client = ResourceManagementClient(credential, self.subscription_id)
+        if resource_client.resource_groups.check_existence(AzureServer.resource_group_name):
+            # Resource group already exists.
+            # Take this moment to search for orphaned resources and clean them up...
+            network_client = NetworkManagementClient(credential, self.subscription_id)
+            if clean_up_orphans:
+                logger.info("Searching for orphaned Azure resources...")
+                for vnet in network_client.virtual_networks.list(AzureServer.resource_group_name):
+                    if vnet.tags.get("skylark", None) == "true" and AzureServer.is_valid_vnet_name(vnet.name):
+                        name = AzureServer.base_name_from_vnet_name(vnet.name)
+                        s = AzureServer(self.subscription_id, name, assume_exists=False)
+                        if not s.is_valid():
+                            logger.warning(f"Cleaning up orphaned Azure resources for {name}...")
+                            s.terminate_instance_impl()
+                logger.info("Done cleaning up orphaned Azure resources")
+            return
+        rg_result = resource_client.resource_groups.create_or_update(
+            AzureServer.resource_group_name, {"location": AzureServer.resource_group_location, "tags": {"skylark": "true"}}
+        )
+        assert rg_result.name == AzureServer.resource_group_name
 
     # This code, along with some code in azure_server.py, is based on
     # https://github.com/ucbrise/mage-scripts/blob/main/azure_cloud.py.
@@ -305,18 +328,18 @@ class AzureCloudProvider(CloudProvider):
         credential = self.credential
         compute_client = ComputeManagementClient(credential, self.subscription_id)
         network_client = NetworkManagementClient(credential, self.subscription_id)
-        resource_client = ResourceManagementClient(credential, self.subscription_id)
 
-        # Create a resource group for this instance
-        resource_group = name
-        if resource_client.resource_groups.check_existence(resource_group):
-            raise RuntimeError('Cannot spawn instance "{0}": instance already exists'.format(name))
-        rg_result = resource_client.resource_groups.create_or_update(resource_group, {"location": location, "tags": {"skylark": "true"}})
-        assert rg_result.name == resource_group
+        # Use the common resource group for this instance
+        resource_group = AzureServer.resource_group_name
+
+        # TODO: On future requests to create resources, check if a resource
+        # with that name already exists, and fail the operation if so
 
         # Create a Virtual Network for this instance
         poller = network_client.virtual_networks.begin_create_or_update(
-            resource_group, AzureServer.vnet_name(name), {"location": location, "address_space": {"address_prefixes": ["10.0.0.0/24"]}}
+            resource_group,
+            AzureServer.vnet_name(name),
+            {"location": location, "tags": {"skylark": "true"}, "address_space": {"address_prefixes": ["10.0.0.0/24"]}},
         )
         poller.result()
 
@@ -327,6 +350,7 @@ class AzureCloudProvider(CloudProvider):
             AzureServer.nsg_name(name),
             {
                 "location": location,
+                "tags": {"skylark": "true"},
                 "security_rules": [
                     {
                         "name": name + "-allow-all",
@@ -346,26 +370,28 @@ class AzureCloudProvider(CloudProvider):
         nsg_result = poller.result()
 
         # Create a subnet for this instance with the above Network Security Group
-        poller = network_client.subnets.begin_create_or_update(
+        subnet_poller = network_client.subnets.begin_create_or_update(
             resource_group,
             AzureServer.vnet_name(name),
             AzureServer.subnet_name(name),
             {"address_prefix": "10.0.0.0/26", "network_security_group": {"id": nsg_result.id}},
         )
-        subnet_result = poller.result()
 
         # Create a public IPv4 address for this instance
-        poller = network_client.public_ip_addresses.begin_create_or_update(
+        ip_poller = network_client.public_ip_addresses.begin_create_or_update(
             resource_group,
             AzureServer.ip_name(name),
             {
                 "location": location,
+                "tags": {"skylark": "true"},
                 "sku": {"name": "Standard"},
                 "public_ip_allocation_method": "Static",
                 "public_ip_address_version": "IPV4",
             },
         )
-        public_ip_result = poller.result()
+
+        subnet_result = subnet_poller.result()
+        public_ip_result = ip_poller.result()
 
         # Create a NIC for this instance, with accelerated networking enabled
         poller = network_client.network_interfaces.begin_create_or_update(
@@ -373,6 +399,7 @@ class AzureCloudProvider(CloudProvider):
             AzureServer.nic_name(name),
             {
                 "location": location,
+                "tags": {"skylark": "true"},
                 "ip_configurations": [
                     {"name": name + "-ip", "subnet": {"id": subnet_result.id}, "public_ip_address": {"id": public_ip_result.id}}
                 ],
@@ -388,6 +415,7 @@ class AzureCloudProvider(CloudProvider):
                 AzureServer.vm_name(name),
                 {
                     "location": location,
+                    "tags": {"skylark": "true"},
                     "hardware_profile": {"vm_size": self.lookup_valid_instance(location, vm_size)},
                     "storage_profile": {
                         "image_reference": {
@@ -395,7 +423,8 @@ class AzureCloudProvider(CloudProvider):
                             "offer": "0001-com-ubuntu-server-focal",
                             "sku": "20_04-lts",
                             "version": "latest",
-                        }
+                        },
+                        "os_disk": {"create_option": "FromImage", "delete_option": "Delete"},
                     },
                     "os_profile": {
                         "computer_name": AzureServer.vm_name(name),
@@ -410,4 +439,4 @@ class AzureCloudProvider(CloudProvider):
             )
             poller.result()
 
-        return AzureServer(self.subscription_id, resource_group)
+        return AzureServer(self.subscription_id, name)

--- a/skylark/replicate/replicator_client.py
+++ b/skylark/replicate/replicator_client.py
@@ -54,6 +54,7 @@ class ReplicatorClient:
                 jobs.append(partial(self.aws.add_ip_to_security_group, r))
         if self.azure is not None:
             jobs.append(self.azure.create_ssh_key)
+            jobs.append(self.azure.set_up_resource_group)
         if self.gcp is not None:
             jobs.append(self.gcp.create_ssh_key)
             jobs.append(self.gcp.configure_default_network)


### PR DESCRIPTION
Fixes: #125 

This pull request modifies Skylark's Azure support to use a single `skylark` resource group for all resources spawned for a transfer, across all Azure regions. Previously, Skylark would create a separate resource group for each VM and its associated resources (disk, NIC, public IP address, etc.). The motivation behind this change is to make Azure operations faster and more reliable, since we found that performing operations on resource groups can be quite slow.