### PR TITLE
Log transfer details to error logging dir

### DIFF
--- a/scripts/create_test_data.py
+++ b/scripts/create_test_data.py
@@ -2,7 +2,7 @@ from skylark import GB, MB, print_header
 import shutil
 import os
 import argparse
-from tqdm import tqdm 
+from tqdm import tqdm
 
 
 def parse_args():
@@ -13,20 +13,19 @@ def parse_args():
     args = parser.parse_args()
     return args
 
+
 def main(args):
     directory = f"{args.directory}/{args.chunk_size_mb}_{args.n_chunks}/"
 
-    if os.path.isdir(directory): 
-        shutil.rmtree(directory) 
+    if os.path.isdir(directory):
+        shutil.rmtree(directory)
     os.mkdir(directory)
 
-    for chunk in tqdm(range(args.n_chunks)): 
+    for chunk in tqdm(range(args.n_chunks)):
         with open(f"{directory}/chunk_{chunk}", "wb") as f:
             f.write(os.urandom(int(MB * args.chunk_size_mb)))
+
 
 if __name__ == "__main__":
     print_header()
     main(parse_args())
- 
-
-

--- a/scripts/ray_cluster/script.py
+++ b/scripts/ray_cluster/script.py
@@ -4,12 +4,17 @@ import time
 
 import ray
 
-ray.init(address='auto')
+ray.init(address="auto")
 
-print('''This cluster consists of
+print(
+    """This cluster consists of
     {} nodes in total
     {} CPU resources in total
-'''.format(len(ray.nodes()), ray.cluster_resources()['CPU']))
+""".format(
+        len(ray.nodes()), ray.cluster_resources()["CPU"]
+    )
+)
+
 
 @ray.remote
 def f():
@@ -17,9 +22,10 @@ def f():
     # Return IP address.
     return socket.gethostbyname(socket.gethostname())
 
+
 object_ids = [f.remote() for _ in range(10000)]
 ip_addresses = ray.get(object_ids)
 
-print('Tasks executed')
+print("Tasks executed")
 for ip_address, num_tasks in Counter(ip_addresses).items():
-    print('    {} tasks on {}'.format(num_tasks, ip_address))
+    print("    {} tasks on {}".format(num_tasks, ip_address))

--- a/skylark/replicate/profiler.py
+++ b/skylark/replicate/profiler.py
@@ -16,7 +16,7 @@ def status_df_to_traceevent(log_df) -> List[Dict]:
                     "name": f"Download {row['chunk_id']}",
                     "ts": (row["time"] - start_time).total_seconds() * 1e6,
                     "pid": f"{row['region']}:{row['instance']}",
-                    "tid": row["receiver_id"],
+                    "tid": row.get("receiver_id"),
                     "ph": "B",
                 }
             )
@@ -26,7 +26,7 @@ def status_df_to_traceevent(log_df) -> List[Dict]:
                     "name": f"Download {row['chunk_id']}",
                     "ts": (row["time"] - start_time).total_seconds() * 1e6,
                     "pid": f"{row['region']}:{row['instance']}",
-                    "tid": row["receiver_id"],
+                    "tid": row.get("receiver_id"),
                     "ph": "E",
                 }
             )
@@ -36,7 +36,7 @@ def status_df_to_traceevent(log_df) -> List[Dict]:
                     "name": f"Upload {row['chunk_id']}",
                     "ts": (row["time"] - start_time).total_seconds() * 1e6,
                     "pid": f"{row['region']}:{row['instance']}",
-                    "tid": row["sender_id"],
+                    "tid": row.get("sender_id"),
                     "ph": "B",
                 }
             )
@@ -46,7 +46,7 @@ def status_df_to_traceevent(log_df) -> List[Dict]:
                     "name": f"Upload {row['chunk_id']}",
                     "ts": (row["time"] - start_time).total_seconds() * 1e6,
                     "pid": f"{row['region']}:{row['instance']}",
-                    "tid": row["sender_id"],
+                    "tid": row.get("sender_id"),
                     "ph": "E",
                 }
             )

--- a/skylark/replicate/replicator_client.py
+++ b/skylark/replicate/replicator_client.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import itertools
 from functools import partial
 import json
+import pickle
 import time
 from typing import Dict, List, Optional, Tuple
 import uuid
@@ -308,6 +309,7 @@ class ReplicatorClient:
         log_interval_s: Optional[float] = None,
         time_limit_seconds: Optional[float] = None,
         cancel_pending: bool = True,
+        save_log: bool = True,
         write_profile: bool = True,
         copy_gateway_logs: bool = True,
     ) -> Dict:
@@ -321,6 +323,8 @@ class ReplicatorClient:
         def shutdown_handler():
             transfer_dir = tmp_log_dir / f"transfer_{datetime.now().isoformat()}"
             transfer_dir.mkdir(exist_ok=True, parents=True)
+            if save_log:
+                (transfer_dir / "job.pkl").write_bytes(pickle.dumps(job))
             if copy_gateway_logs:
                 for instance in self.bound_nodes.values():
                     stdout, stderr = instance.run_command("sudo docker logs -t skylark_gateway")
@@ -328,7 +332,9 @@ class ReplicatorClient:
                     log_out.write_text(stdout + "\n" + stderr)
                 logger.debug(f"Wrote gateway logs to {transfer_dir}")
             if write_profile:
-                traceevent = status_df_to_traceevent(self.get_chunk_status_log_df())
+                chunk_status_df = self.get_chunk_status_log_df()
+                (transfer_dir / "chunk_status_df.csv").write_text(chunk_status_df.to_csv(index=False))
+                traceevent = status_df_to_traceevent(chunk_status_df)
                 profile_out = transfer_dir / f"traceevent_{uuid.uuid4()}.json"
                 profile_out.parent.mkdir(parents=True, exist_ok=True)
                 profile_out.write_text(json.dumps(traceevent))


### PR DESCRIPTION
Logs ReplicationJob details to a pickle in the error logging directory and also fixes an error w/ missing keys in profiler.py﻿
