### PR TITLE
updated readme with netcat installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This package represents both components as a single binary. Docker builds a sing
 	* (1) Install AWS CLI with `sudo apt install awscli`
 	* (2) Configure AWS by running `aws configure` and input the necessary information. See https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html. 
 	* (3) Ensure that you have a sufficient AWS vCPU limit in any regions you intend to use
+    * (4) Install netcat with `sudo apt install nc`
 
 ### Building and deploying the gateway
 


### PR DESCRIPTION
Using skylark on a vanilla AWS EC2 instance requires installation of netcat (nc) to work properly. To avoid confusion for the user, this one line installation instruction was added to the README.