### PR TITLE
Fix gateway log download when transferring many chunks

### DIFF
--- a/skylark/compute/server.py
+++ b/skylark/compute/server.py
@@ -175,6 +175,12 @@ class Server:
         self.add_command_log(command=command, stdout=stdout, stderr=stderr, runtime=t.elapsed)
         return stdout, stderr
 
+    def download_file(self, remote_path, local_path):
+        """Download a file from the server"""
+        client = self.ssh_client
+        with client.open_sftp() as sftp:
+            sftp.get(remote_path, local_path)
+
     def copy_public_key(self, pub_key_path: PathLike):
         """Append public key to authorized_keys file on server."""
         pub_key_path = Path(pub_key_path)

--- a/skylark/replicate/replicator_client.py
+++ b/skylark/replicate/replicator_client.py
@@ -327,9 +327,10 @@ class ReplicatorClient:
                 (transfer_dir / "job.pkl").write_bytes(pickle.dumps(job))
             if copy_gateway_logs:
                 for instance in self.bound_nodes.values():
-                    stdout, stderr = instance.run_command("sudo docker logs -t skylark_gateway")
+                    logger.info(f"Copying gateway logs from {instance.uuid()}")
+                    instance.run_command("sudo docker logs -t skylark_gateway &> /tmp/gateway.log")
                     log_out = transfer_dir / f"gateway_{instance.uuid()}.log"
-                    log_out.write_text(stdout + "\n" + stderr)
+                    instance.download_file("/tmp/gateway.log", log_out)
                 logger.debug(f"Wrote gateway logs to {transfer_dir}")
             if write_profile:
                 chunk_status_df = self.get_chunk_status_log_df()


### PR DESCRIPTION
If there are too many chunks, the download of logs can be slow. Use SFTP to download log files instead of downloading via standard out.﻿
