### PR TITLE
cp rework 2 

### DIFF
--- a/skylark/cli/cli.py
+++ b/skylark/cli/cli.py
@@ -155,7 +155,14 @@ def cp(
             for i in range(max_instances):
                 topo.add_edge(src_region, i, dst_region, i, num_connections)
 
-        replicate_helper(topo, source_bucket=bucket_src, dest_bucket=bucket_dst, src_key_prefix=path_src, dest_key_prefix=path_dst, reuse_gateways=reuse_gateways)
+        replicate_helper(
+            topo,
+            source_bucket=bucket_src,
+            dest_bucket=bucket_dst,
+            src_key_prefix=path_src,
+            dest_key_prefix=path_dst,
+            reuse_gateways=reuse_gateways,
+        )
     else:
         raise NotImplementedError(f"{provider_src} to {provider_dst} not supported yet")
 

--- a/skylark/cli/cli_helper.py
+++ b/skylark/cli/cli_helper.py
@@ -15,7 +15,6 @@ from typing import Dict, List
 from urllib.parse import ParseResultBytes, parse_qs
 
 
-
 import boto3
 import typer
 from skylark import GB, MB
@@ -56,7 +55,7 @@ def parse_path(path: str):
         if len(parsed) == 1:
             bucket_name, key_name = parsed[0], "/"
         else:
-            if (parsed[1] == ''):
+            if parsed[1] == "":
                 bucket_name, key_name = parsed[0], "/"
             else:
                 bucket_name, key_name = parsed[0], parsed[1]
@@ -66,7 +65,7 @@ def parse_path(path: str):
         if len(parsed) == 1:
             bucket_name, key_name = parsed[0], "/"
         else:
-            if (parsed[1] == ''):
+            if parsed[1] == "":
                 bucket_name, key_name = parsed[0], "/"
             else:
                 bucket_name, key_name = parsed[0], parsed[1]
@@ -246,9 +245,9 @@ def replicate_helper(
         # make replication job
         src_objs = list(ObjectStoreInterface.create(topo.source_region(), source_bucket).list_objects(src_key_prefix))
         dest_is_directory = False
-        if (dest_key_prefix.endswith('/')):
+        if dest_key_prefix.endswith("/"):
             dest_is_directory = True
-        
+
         job = ReplicationJob(
             source_region=topo.source_region(),
             source_bucket=source_bucket,


### PR DESCRIPTION
Couple notes fixing discrepancies between cp and how it works in linux:

- cp will overwrite an existing file with new file contents if the dest file prefix already exists in the dest bucket, no more name concatenation (fixes #280)
- trailing slashes are required for directories, as is convention with s3 and in linux convention
- trailing slashes are optional at root bucket level
- "-r" flag was not added as by default directories are recursively copied.