### PR TITLE
Fix #366: explicit package discovery of skyplane package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@
 import setuptools
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(packages=["skyplane"])


### PR DESCRIPTION
Fixes #366﻿ by explicitly specifying package directory in setup.py