### PR TITLE
Update integration test with new service account upon deprovision

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     needs: [integration]
+    env:
+      STRATEGY_UUID: skyplane-integrationtest-deprovision-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python 3.8
@@ -90,7 +92,14 @@ jobs:
         uses: 'google-github-actions/auth@v0'
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS_JSON }}'
+      - name: Delete existing service account keys
+        run: (gcloud iam service-accounts keys list --project skyplane-ci --iam-account ${{ env.STRATEGY_UUID }}@skyplane-ci.iam.gserviceaccount.com --format="value(KEY_ID)" | xargs -I {} gcloud iam service-accounts keys delete --project skyplane-ci --iam-account ${{ env.STRATEGY_UUID }}@skyplane-ci.iam.gserviceaccount.com -q {}) || true
       - name: Skyplane init
-        run: poetry run skyplane init -y --disable-config-azure
+        run: |
+          poetry run skyplane config set gcp_service_account_name ${{ env.STRATEGY_UUID }}
+          poetry run skyplane init -y --disable-config-azure
       - name: Deprovision
-        run: poetry run skyplane deprovision
+        run: poetry run skyplane deprovisio
+      - name: Cleanup GCP service account
+        if: always()
+        run: (gcloud iam service-accounts keys list --project skyplane-ci --iam-account ${{ env.STRATEGY_UUID }}@skyplane-ci.iam.gserviceaccount.com --format="value(KEY_ID)" | xargs -I {} gcloud iam service-accounts keys delete --project skyplane-ci --iam-account ${{ env.STRATEGY_UUID }}@skyplane-ci.iam.gserviceaccount.com -q {}) || true


### PR DESCRIPTION
Avoids adding extra keys to `skyplane-manual` service account.