### PR TITLE
Support GCP copies to/from unowned buckets

### DIFF
--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -120,10 +120,10 @@ def generate_full_transferobjlist(
     dest_iface = ObjectStoreInterface.create(dest_region, dest_bucket)
 
     # ensure buckets exist
-    if not source_iface.bucket_exists():
-        raise exceptions.MissingBucketException(f"Source bucket {source_bucket} does not exist")
-    if not dest_iface.bucket_exists():
-        raise exceptions.MissingBucketException(f"Destination bucket {dest_bucket} does not exist")
+    # if not source_iface.bucket_exists():
+    #     raise exceptions.MissingBucketException(f"Source bucket {source_bucket} does not exist")
+    # if not dest_iface.bucket_exists():
+    #     raise exceptions.MissingBucketException(f"Destination bucket {dest_bucket} does not exist")
 
     source_objs, dest_objs = [], []
 

--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -120,10 +120,10 @@ def generate_full_transferobjlist(
     dest_iface = ObjectStoreInterface.create(dest_region, dest_bucket)
 
     # ensure buckets exist
-    # if not source_iface.bucket_exists():
-    #     raise exceptions.MissingBucketException(f"Source bucket {source_bucket} does not exist")
-    # if not dest_iface.bucket_exists():
-    #     raise exceptions.MissingBucketException(f"Destination bucket {dest_bucket} does not exist")
+    if not source_iface.bucket_exists():
+        raise exceptions.MissingBucketException(f"Source bucket {source_bucket} does not exist")
+    if not dest_iface.bucket_exists():
+        raise exceptions.MissingBucketException(f"Destination bucket {dest_bucket} does not exist")
 
     source_objs, dest_objs = [], []
 

--- a/skyplane/obj_store/gcs_interface.py
+++ b/skyplane/obj_store/gcs_interface.py
@@ -4,7 +4,7 @@ import hashlib
 import os
 import requests
 from functools import lru_cache
-from typing import Iterator, List, Optional
+from typing import Iterator, List, Optional, Tuple
 from xml.etree import ElementTree
 
 from skyplane import exceptions
@@ -26,7 +26,7 @@ class GCSInterface(ObjectStoreInterface):
         self.auth = GCPAuthentication()
         self._gcs_client = self.auth.get_storage_client()
         self._requests_session = requests.Session()
-        self.gcp_region = self.infer_gcp_region(bucket_name) if gcp_region == "infer" else gcp_region
+        self.owned_bucket, self.gcp_region = self.infer_gcp_region(bucket_name) if gcp_region == "infer" else (None, gcp_region)
 
     def region_tag(self):
         return "gcp:" + self.gcp_region
@@ -45,24 +45,30 @@ class GCSInterface(ObjectStoreInterface):
                     return zone["name"]
         raise ValueError(f"No GCP zone found for region {region}")
 
-    def infer_gcp_region(self, bucket_name: str):
+    def infer_gcp_region(self, bucket_name: str) -> Tuple[bool, str]:
+        """Returns if the bucket is owned by the current user as well as the region of the bucket."""
         try:
             bucket = self._gcs_client.lookup_bucket(bucket_name)
         except Exception as e:
             # does not have storage.buckets.get access to the Google Cloud Storage bucket
             if "access to the Google Cloud Storage bucket" in str(e):
-                logger.warning(f"No access to the Google Cloud Storage bucket '{bucket_name}': {e}")
-                logger.warning(f"Assuming '{bucket_name}' is in the 'us-central1-a' zone")
-                return "us-central1-a"
+                logger.warning(f"No access to the Google Cloud Storage bucket '{bucket_name}', assuming bucket is in the 'us-central1-a' zone")
+                return False, "us-central1-a"
         if bucket is None:
             raise exceptions.MissingBucketException(f"GCS bucket {bucket_name} does not exist")
-        return self.map_region_to_zone(bucket.location.lower())
+        return True, self.map_region_to_zone(bucket.location.lower())
 
     def bucket_exists(self):
+        if self.owned_bucket is not None and not self.owned_bucket:
+            logger.warning(f"Bucket {self.bucket_name} is not owned by the current user, so we cannot check if it exists.")
+            return True
         try:
             self._gcs_client.get_bucket(self.bucket_name)
             return True
-        except Exception:
+        except Exception as e:
+            if "does not have storage.buckets.get access to the Google Cloud Storage bucket" in str(e):
+                logger.warning(f"Bucket {self.bucket_name} is not owned by the current user, so we cannot check if it exists.")
+                return True
             return False
 
     def exists(self, obj_name):

--- a/skyplane/obj_store/gcs_interface.py
+++ b/skyplane/obj_store/gcs_interface.py
@@ -10,9 +10,7 @@ from xml.etree import ElementTree
 from skyplane import exceptions
 from skyplane.utils import logger
 from skyplane.compute.gcp.gcp_auth import GCPAuthentication
-from skyplane.obj_store.object_store_interface import (NoSuchObjectException,
-                                                       ObjectStoreInterface,
-                                                       ObjectStoreObject)
+from skyplane.obj_store.object_store_interface import NoSuchObjectException, ObjectStoreInterface, ObjectStoreObject
 
 
 class GCSObject(ObjectStoreObject):
@@ -52,7 +50,9 @@ class GCSInterface(ObjectStoreInterface):
         except Exception as e:
             # does not have storage.buckets.get access to the Google Cloud Storage bucket
             if "access to the Google Cloud Storage bucket" in str(e):
-                logger.warning(f"No access to the Google Cloud Storage bucket '{bucket_name}', assuming bucket is in the 'us-central1-a' zone")
+                logger.warning(
+                    f"No access to the Google Cloud Storage bucket '{bucket_name}', assuming bucket is in the 'us-central1-a' zone"
+                )
                 return False, "us-central1-a"
         if bucket is None:
             raise exceptions.MissingBucketException(f"GCS bucket {bucket_name} does not exist")


### PR DESCRIPTION
For buckets owned by a third party, reads and writes may succeed but bucket properties may not be readable. This PR supports these buckets while emitting an error that bucket existence cannot be verified.