### PR TITLE
Clean up object store interfaces

### DIFF
--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -103,18 +103,13 @@ def cp(
 
     clouds = {"s3": "aws:infer", "gs": "gcp:infer", "azure": "azure:infer"}
 
-    # error for local transfers
-    def error_local():
+    if provider_src == "local" or provider_dst == "local":
         typer.secho("Local transfers are not yet supported (but will be soon!)", fg="red")
         typer.secho("Skyplane is currently most optimized for cloud to cloud transfers.", fg="yellow")
         typer.secho(
             "Please provide feedback for on prem transfers at: https://github.com/skyplane-project/skyplane/discussions/424", fg="yellow"
         )
         raise typer.Exit(code=1)
-
-    # raise file limits for local transfers
-    if provider_src == "local" or provider_dst == "local":
-        error_local()
     if provider_src in clouds and provider_dst in clouds:
         try:
             src_client = ObjectStoreInterface.create(clouds[provider_src], bucket_src)

--- a/skyplane/cli/cli_aws.py
+++ b/skyplane/cli/cli_aws.py
@@ -41,8 +41,8 @@ def vcpu_limits(quota_code="L-1216C47A"):
 @app.command()
 def cp_datasync(src_bucket: str, dst_bucket: str, path: str):
     aws_auth = AWSAuthentication()
-    src_region = S3Interface(src_bucket, aws_region="infer").aws_region
-    dst_region = S3Interface(dst_bucket, aws_region="infer").aws_region
+    src_region = S3Interface(src_bucket).aws_region
+    dst_region = S3Interface(dst_bucket).aws_region
 
     iam_client = aws_auth.get_boto3_client("iam", "us-east-1")
     try:

--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -13,7 +13,7 @@ from skyplane.compute.cloud_providers import CloudProvider
 from skyplane.obj_store.object_store_interface import ObjectStoreInterface, ObjectStoreObject
 from skyplane.obj_store.s3_interface import S3Object
 from skyplane.obj_store.gcs_interface import GCSObject
-from skyplane.obj_store.azure_interface import AzureObject
+from skyplane.obj_store.azure_blob_interface import AzureBlobObject
 from skyplane.replicate.replication_plan import ReplicationTopology, ReplicationJob
 from skyplane.replicate.replicator_client import ReplicatorClient
 from skyplane.utils import logger
@@ -148,7 +148,7 @@ def generate_full_transferobjlist(
         elif dest_region.startswith("gcp"):
             dest_obj = GCSObject(dest_region.split(":")[0], dest_bucket, dest_key)
         elif dest_region.startswith("azure"):
-            dest_obj = AzureObject(dest_region.split(":")[0], dest_bucket, dest_key)
+            dest_obj = AzureBlobObject(dest_region.split(":")[0], dest_bucket, dest_key)
         else:
             raise ValueError(f"Invalid dest_region {dest_region} - could not create corresponding object")
         # dest_obj = ObjectStoreObject(dest_region.split(":")[0], dest_bucket, dest_key)

--- a/skyplane/exceptions.py
+++ b/skyplane/exceptions.py
@@ -43,3 +43,7 @@ class TransferFailedException(SkyplaneException):
         if self.failed_objects and len(self.failed_objects) > 0:
             err += "\n[bold][red]Failed objects:[/red][/bold] " + str(self.failed_objects)
         return err
+
+
+class NoSuchObjectException(Exception):
+    pass

--- a/skyplane/gateway/gateway_obj_store.py
+++ b/skyplane/gateway/gateway_obj_store.py
@@ -43,7 +43,7 @@ class GatewayObjStoreConn:
     def get_obj_store_interface(self, region: str, bucket: str) -> ObjectStoreInterface:
         key = f"{region}:{bucket}"
         if key not in self.obj_store_interfaces:
-            logger.warning(f"[gateway_daemon] ObjectStoreInferface not cached for {key}")
+            logger.warning(f"[gateway_daemon] ObjectStoreInterface not cached for {key}")
             try:
                 self.obj_store_interfaces[key] = ObjectStoreInterface.create(region, bucket)
             except Exception as e:

--- a/skyplane/obj_store/azure_blob_interface.py
+++ b/skyplane/obj_store/azure_blob_interface.py
@@ -1,67 +1,46 @@
 import base64
 import hashlib
 import os
-import subprocess
 import time
-import uuid
 from functools import lru_cache, partial
 from typing import Iterator, List, Optional
 
 from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError, HttpResponseError
-from azure.identity import AzureCliCredential
-from azure.mgmt.authorization.models import RoleAssignmentCreateParameters, RoleAssignmentProperties
 
 from skyplane import exceptions, is_gateway_env
 from skyplane.compute.azure.azure_auth import AzureAuthentication
 from skyplane.compute.azure.azure_server import AzureServer
-from skyplane.obj_store.object_store_interface import NoSuchObjectException, ObjectStoreInterface, ObjectStoreObject
+from skyplane.obj_store.azure_storage_account_interface import AzureStorageAccountInterface
+from skyplane.obj_store.object_store_interface import ObjectStoreInterface, ObjectStoreObject
+from skyplane.exceptions import NoSuchObjectException
 from skyplane.utils import logger
 from skyplane.utils.timer import Timer
 
 
-class AzureObject(ObjectStoreObject):
+class AzureBlobObject(ObjectStoreObject):
     def full_path(self):
         account_name, container_name = self.bucket.split("/")
         return os.path.join(f"https://{account_name}.blob.core.windows.net", container_name, self.key)
 
 
-class AzureInterface(ObjectStoreInterface):
-    def __init__(self, account_name: str, container_name: str, region: str = "infer", max_concurrency=1):
+class AzureBlobInterface(ObjectStoreInterface):
+    def __init__(self, account_name: str, container_name: str, max_concurrency=1):
         self.auth = AzureAuthentication()
+        self.storage_account_interface = AzureStorageAccountInterface(account_name)
         self.account_name = account_name
         self.container_name = container_name
-        self.account_url = f"https://{self.account_name}.blob.core.windows.net"
         self.max_concurrency = max_concurrency  # parallel upload/downloads, seems to cause issues if too high
-        self.azure_region = self.query_storage_account(self.account_name).location if region == "infer" else region
+
+    def region_tag(self):
+        return f"azure:{self.storage_account_interface.azure_region}"
 
     @property
     def blob_service_client(self):
-        return self.auth.get_blob_service_client(self.account_url)
+        return self.auth.get_blob_service_client(f"https://{self.account_name}.blob.core.windows.net")
 
     @property
     def container_client(self):
-        return self.auth.get_container_client(self.account_url, self.container_name)
-
-    @property
-    def storage_management_client(self):
-        return self.auth.get_storage_management_client()
-
-    def region_tag(self):
-        return "azure:" + self.azure_region
-
-    def query_storage_account(self, storage_account_name):
-        for account in self.storage_management_client.storage_accounts.list():
-            if account.name == storage_account_name:
-                return account
-        raise ValueError(
-            f"Storage account {storage_account_name} not found (found {[account.name for account in self.storage_management_client.storage_accounts.list()]})"
-        )
-
-    def storage_account_exists(self):
-        for account in self.storage_management_client.storage_accounts.list():
-            if account.name == self.account_name:
-                return True
-        return False
+        return self.auth.get_container_client(f"https://{self.account_name}.blob.core.windows.net", self.container_name)
 
     def container_exists(self):
         try:
@@ -71,48 +50,10 @@ class AzureInterface(ObjectStoreInterface):
             return False
 
     def bucket_exists(self):
-        return self.storage_account_exists() and self.container_exists()
+        return self.storage_account_interface.storage_account_exists() and self.container_exists()
 
     def exists(self, obj_name):
         return self.blob_service_client.get_blob_client(container=self.container_name, blob=obj_name).exists()
-
-    def create_storage_account(self, tier="Premium_LRS"):
-        try:
-            operation = self.storage_management_client.storage_accounts.begin_create(
-                AzureServer.resource_group_name,
-                self.account_name,
-                {"sku": {"name": tier}, "kind": "BlockBlobStorage", "location": self.azure_region},
-            )
-            operation.result()
-        except ResourceExistsError as e:
-            logger.warning(f"Unable to create storage account as it already exists: {e}")
-
-    def infer_cli_principal_id(self):
-        self.auth.credential.get_token("https://graph.windows.net")  # must request token to attempt to load credential
-        if isinstance(self.auth.credential._successful_credential, AzureCliCredential):
-            out = subprocess.check_output(["az", "ad", "signed-in-user", "show", "--query", "objectId", "-o", "tsv"])
-            return out.decode("utf-8").strip()
-        else:
-            return None
-
-    def grant_storage_account_access(self, role_name: str, principal_id: str):
-        # lookup role
-        auth_client = self.auth.get_authorization_client()
-        scope = f"/subscriptions/{self.auth.subscription_id}/resourceGroups/{AzureServer.resource_group_name}/providers/Microsoft.Storage/storageAccounts/{self.account_name}"
-        roles = list(auth_client.role_definitions.list(scope, filter="roleName eq '{}'".format(role_name)))
-        assert len(roles) == 1
-
-        # query for existing role assignment
-        matches = []
-        for assignment in auth_client.role_assignments.list_for_scope(scope, filter="principalId eq '{}'".format(principal_id)):
-            if assignment.role_definition_id == roles[0].id:
-                matches.append(assignment)
-        if len(matches) == 0:
-            logger.debug(f"Granting access to {principal_id} for role {role_name} on storage account {self.account_name}")
-            params = RoleAssignmentCreateParameters(
-                properties=RoleAssignmentProperties(role_definition_id=roles[0].id, principal_id=principal_id)
-            )
-            auth_client.role_assignments.create(scope, uuid.uuid4(), params)
 
     def create_container(self):
         try:
@@ -120,14 +61,11 @@ class AzureInterface(ObjectStoreInterface):
         except ResourceExistsError:
             logger.warning(f"Unable to create container {self.container_name} as it already exists")
 
-    def create_bucket(self, premium_tier=True):
+    def create_bucket(self, azure_region, resource_group=AzureServer.resource_group_name, premium_tier=True):
         tier = "Premium_LRS" if premium_tier else "Standard_LRS"
-        if not self.storage_account_exists():
+        if not self.storage_account_interface.storage_account_exists():
             logger.debug(f"Creating storage account {self.account_name}")
-            self.create_storage_account(tier=tier)
-        principal_id = self.infer_cli_principal_id()
-        if principal_id:
-            self.grant_storage_account_access("Storage Blob Data Contributor", principal_id)
+            self.storage_account_interface.create_storage_account(azure_region, resource_group, tier)
         if not self.container_exists():
             logger.debug(f"Creating container {self.container_name}")
             self.create_container()
@@ -141,11 +79,11 @@ class AzureInterface(ObjectStoreInterface):
     def delete_bucket(self):
         return self.delete_container()
 
-    def list_objects(self, prefix="") -> Iterator[AzureObject]:
+    def list_objects(self, prefix="") -> Iterator[AzureBlobObject]:
         blobs = self.container_client.list_blobs(name_starts_with=prefix)
         try:
             for blob in blobs:
-                yield AzureObject("azure", f"{self.account_name}/{blob.container}", blob.name, blob.size, blob.last_modified)
+                yield AzureBlobObject("azure", f"{self.account_name}/{blob.container}", blob.name, blob.size, blob.last_modified)
         except HttpResponseError as e:
             if "AuthorizationPermissionMismatch" in str(e):
                 logger.error(
@@ -249,6 +187,6 @@ class AzureInterface(ObjectStoreInterface):
             blob_md5 = blob_client.get_blob_properties().properties.content_settings.content_md5
             if b64_md5sum != blob_md5:
                 raise exceptions.ChecksumMismatchException(
-                    f"Checksum mismatch for object {dst_object_name} in bucket {self.bucket_name}, "
+                    f"Checksum mismatch for object {dst_object_name} in Azure container {self.container_name}, "
                     + f"expected {b64_md5sum}, got {blob_md5}"
                 )

--- a/skyplane/obj_store/azure_storage_account_interface.py
+++ b/skyplane/obj_store/azure_storage_account_interface.py
@@ -1,0 +1,84 @@
+import uuid
+from functools import lru_cache
+
+from azure.core.exceptions import ResourceExistsError
+from azure.mgmt.authorization.v2015_07_01.models import RoleAssignmentCreateParameters, RoleAssignmentProperties
+
+from skyplane import exceptions
+from skyplane.compute.azure.azure_auth import AzureAuthentication
+from skyplane.compute.azure.azure_server import AzureServer
+from skyplane.utils import logger
+
+
+class AzureStorageAccountInterface:
+    """Class to manage state for an Azure storage account. Note that storage account names are globally unique."""
+
+    def __init__(self, account_name: str):
+        self.auth = AzureAuthentication()
+        self.account_name = account_name
+
+    @lru_cache
+    def storage_account_obj(self):
+        sm_client = self.auth.get_storage_management_client()
+        storage_accounts = sm_client.storage_accounts.list()
+        for storage_account in storage_accounts:
+            if storage_account.name == self.account_name:
+                return storage_account
+        raise exceptions.MissingBucketException(f"Storage account {self.account_name} not found")
+
+    @property
+    def azure_region(self):
+        return self.storage_account_obj().location
+
+    @property
+    def azure_resource_group(self):
+        return self.storage_account_obj().resource_group_name
+
+    @property
+    def storage_management_client(self):
+        return self.auth.get_storage_management_client()
+
+    def query_storage_account(self, storage_account_name):
+        for account in self.storage_management_client.storage_accounts.list():
+            if account.name == storage_account_name:
+                return account
+        raise ValueError(
+            f"Storage account {storage_account_name} not found (found {[account.name for account in self.storage_management_client.storage_accounts.list()]})"
+        )
+
+    def storage_account_exists(self):
+        for account in self.storage_management_client.storage_accounts.list():
+            if account.name == self.account_name:
+                return True
+        return False
+
+    def create_storage_account(self, azure_region, resource_group, tier="Premium_LRS"):
+        try:
+            operation = self.storage_management_client.storage_accounts.begin_create(
+                resource_group,
+                self.account_name,
+                {"sku": {"name": tier}, "kind": "BlockBlobStorage", "location": azure_region},
+            )
+            operation.result()
+        except ResourceExistsError as e:
+            logger.warning(f"Unable to create storage account as it already exists: {e}")
+        self.storage_account_obj.cache_clear()
+
+    def grant_storage_account_access(self, role_name: str, principal_id: str):
+        # lookup role
+        auth_client = self.auth.get_authorization_client()
+        scope = f"/subscriptions/{self.auth.subscription_id}/resourceGroups/{self.azure_resource_group}/providers/Microsoft.Storage/storageAccounts/{self.account_name}"
+        roles = list(auth_client.role_definitions.list(scope, filter="roleName eq '{}'".format(role_name)))
+        assert len(roles) == 1
+
+        # query for existing role assignment
+        matches = []
+        for assignment in auth_client.role_assignments.list_for_scope(scope, filter="principalId eq '{}'".format(principal_id)):
+            if assignment.role_definition_id == roles[0].id:
+                matches.append(assignment)
+        if len(matches) == 0:
+            logger.debug(f"Granting access to {principal_id} for role {role_name} on storage account {self.account_name}")
+            params = RoleAssignmentCreateParameters(
+                properties=RoleAssignmentProperties(role_definition_id=roles[0].id, principal_id=principal_id)
+            )
+            auth_client.role_assignments.create(scope, uuid.uuid4(), params)

--- a/skyplane/obj_store/object_store_interface.py
+++ b/skyplane/obj_store/object_store_interface.py
@@ -24,10 +24,7 @@ class ObjectStoreInterface:
     def region_tag(self):
         raise NotImplementedError()
 
-    def bucket_exists(self):
-        raise NotImplementedError()
-
-    def create_bucket(self):
+    def create_bucket(self, region_tag: str):
         raise NotImplementedError()
 
     def delete_bucket(self):
@@ -39,7 +36,7 @@ class ObjectStoreInterface:
     def bucket_exists(self):
         raise NotImplementedError()
 
-    def exists(self):
+    def exists(self, obj_name: str):
         raise NotImplementedError()
 
     def get_obj_size(self, obj_name):
@@ -92,22 +89,15 @@ class ObjectStoreInterface:
         if region_tag.startswith("aws"):
             from skyplane.obj_store.s3_interface import S3Interface
 
-            _, region = region_tag.split(":", 1)
-            return S3Interface(bucket, aws_region=region)
+            return S3Interface(bucket)
         elif region_tag.startswith("gcp"):
             from skyplane.obj_store.gcs_interface import GCSInterface
 
-            _, region = region_tag.split(":", 1)
-            return GCSInterface(bucket, gcp_region=region)
+            return GCSInterface(bucket)
         elif region_tag.startswith("azure"):
-            from skyplane.obj_store.azure_interface import AzureInterface
+            from skyplane.obj_store.azure_blob_interface import AzureBlobInterface
 
             storage_account, container = bucket.split("/", 1)  # <storage_account>/<container>
-            _, region = region_tag.split(":", 1)
-            return AzureInterface(storage_account, container, region=region)
+            return AzureBlobInterface(storage_account, container)
         else:
             raise ValueError(f"Invalid region_tag {region_tag} - could not create interface")
-
-
-class NoSuchObjectException(Exception):
-    pass

--- a/skyplane/obj_store/s3_interface.py
+++ b/skyplane/obj_store/s3_interface.py
@@ -8,7 +8,8 @@ import botocore.exceptions
 
 from skyplane import exceptions
 from skyplane.compute.aws.aws_auth import AWSAuthentication
-from skyplane.obj_store.object_store_interface import NoSuchObjectException, ObjectStoreInterface, ObjectStoreObject
+from skyplane.obj_store.object_store_interface import ObjectStoreInterface, ObjectStoreObject
+from skyplane.exceptions import NoSuchObjectException
 from skyplane.utils import logger
 
 
@@ -18,60 +19,63 @@ class S3Object(ObjectStoreObject):
 
 
 class S3Interface(ObjectStoreInterface):
-    def __init__(self, bucket_name: str, aws_region: str = "infer"):
+    def __init__(self, bucket_name: str):
         self.auth = AWSAuthentication()
         self.bucket_name = bucket_name
-        self.aws_region = self.infer_s3_region(bucket_name) if aws_region == "infer" else aws_region
+
+    @property
+    @lru_cache
+    def aws_region(self):
+        s3_client = self.auth.get_boto3_client("s3")
+        try:
+            region = s3_client.get_bucket_location(Bucket=self.bucket_name).get("LocationConstraint", "us-east-1")
+            return region if region is not None else "us-east-1"
+        except Exception as e:
+            if "An error occurred (AccessDenied) when calling the GetBucketLocation operation" in str(e):
+                logger.error(f"Bucket location {self.bucket_name} is not public. Assuming region is us-east-1.")
+                return "us-east-1"
+            logger.error(f"Specified bucket {self.bucket_name} does not exist, got AWS error: {e}")
+            raise exceptions.MissingBucketException(f"S3 bucket {self.bucket_name} does not exist") from e
 
     def region_tag(self):
         return "aws:" + self.aws_region
 
-    def infer_s3_region(self, bucket_name: str):
-        s3_client = self.auth.get_boto3_client("s3")
-        try:
-            region = s3_client.get_bucket_location(Bucket=bucket_name).get("LocationConstraint", "us-east-1")
-            return region if region is not None else "us-east-1"
-        except Exception as e:
-            if "An error occurred (AccessDenied) when calling the GetBucketLocation operation" in str(e):
-                logger.error(f"Bucket location {bucket_name} is not public. Assuming region is us-east-1.")
-                return "us-east-1"
-            logger.error(f"Specified bucket {bucket_name} does not exist, got AWS error: {e}")
-            raise exceptions.MissingBucketException(f"S3 bucket {bucket_name} does not exist") from e
+    def _s3_client(self, region=None):
+        region = region if region is not None else self.aws_region
+        return self.auth.get_boto3_client("s3", region)
 
     def bucket_exists(self):
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
+        s3_client = self._s3_client("us-east-1")
         return self.bucket_name in [b["Name"] for b in s3_client.list_buckets()["Buckets"]]
 
-    def create_bucket(self, premium_tier=True):
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
+    def create_bucket(self, aws_region):
+        s3_client = self._s3_client(aws_region)
         if not self.bucket_exists():
-            if self.aws_region == "us-east-1":
+            if aws_region == "us-east-1":
                 s3_client.create_bucket(Bucket=self.bucket_name)
             else:
-                s3_client.create_bucket(Bucket=self.bucket_name, CreateBucketConfiguration={"LocationConstraint": self.aws_region})
+                s3_client.create_bucket(Bucket=self.bucket_name, CreateBucketConfiguration={"LocationConstraint": aws_region})
         assert self.bucket_exists()
 
     def delete_bucket(self):
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
-        s3_client.delete_bucket(Bucket=self.bucket_name)
+        self._s3_client().delete_bucket(Bucket=self.bucket_name)
 
     def list_objects(self, prefix="") -> Iterator[S3Object]:
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
-        paginator = s3_client.get_paginator("list_objects_v2")
+        paginator = self._s3_client().get_paginator("list_objects_v2")
         page_iterator = paginator.paginate(Bucket=self.bucket_name, Prefix=prefix)
         for page in page_iterator:
             for obj in page.get("Contents", []):
                 yield S3Object("aws", self.bucket_name, obj["Key"], obj["Size"], obj["LastModified"])
 
     def delete_objects(self, keys: List[str]):
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
+        s3_client = self._s3_client()
         while keys:
             batch, keys = keys[:1000], keys[1000:]  # take up to 1000 keys at a time
             s3_client.delete_objects(Bucket=self.bucket_name, Delete={"Objects": [{"Key": k} for k in batch]})
 
     @lru_cache(maxsize=1024)
     def get_obj_metadata(self, obj_name):
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
+        s3_client = self._s3_client()
         try:
             return s3_client.head_object(Bucket=self.bucket_name, Key=str(obj_name))
         except botocore.exceptions.ClientError as e:
@@ -101,7 +105,7 @@ class S3Interface(ObjectStoreInterface):
         write_block_size=2**16,
     ) -> Optional[bytes]:
         src_object_name, dst_file_path = str(src_object_name), str(dst_file_path)
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
+        s3_client = self._s3_client()
         assert len(src_object_name) > 0, f"Source object name must be non-empty: '{src_object_name}'"
 
         if size_bytes:
@@ -131,7 +135,7 @@ class S3Interface(ObjectStoreInterface):
 
     def upload_object(self, src_file_path, dst_object_name, part_number=None, upload_id=None, check_md5=None):
         dst_object_name, src_file_path = str(dst_object_name), str(src_file_path)
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
+        s3_client = self._s3_client()
         assert len(dst_object_name) > 0, f"Destination object name must be non-empty: '{dst_object_name}'"
         b64_md5sum = base64.b64encode(check_md5).decode("utf-8") if check_md5 else None
         checksum_args = dict(ContentMD5=b64_md5sum) if b64_md5sum else dict()
@@ -163,7 +167,7 @@ class S3Interface(ObjectStoreInterface):
     def initiate_multipart_upload(self, dst_object_name):
         # cannot infer content type here
         assert len(dst_object_name) > 0, f"Destination object name must be non-empty: '{dst_object_name}'"
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
+        s3_client = self._s3_client()
         response = s3_client.create_multipart_upload(
             Bucket=self.bucket_name,
             Key=dst_object_name,
@@ -172,7 +176,7 @@ class S3Interface(ObjectStoreInterface):
         return response["UploadId"]
 
     def complete_multipart_upload(self, dst_object_name, upload_id):
-        s3_client = self.auth.get_boto3_client("s3", self.aws_region)
+        s3_client = self._s3_client()
 
         all_parts = []
         while True:

--- a/skyplane/replicate/replicator_client.py
+++ b/skyplane/replicate/replicator_client.py
@@ -23,7 +23,8 @@ from skyplane.compute.azure.azure_server import AzureServer
 from skyplane.compute.cloud_providers import CloudProvider
 from skyplane.compute.gcp.gcp_cloud_provider import GCPCloudProvider
 from skyplane.compute.server import Server, ServerState
-from skyplane.obj_store.object_store_interface import ObjectStoreInterface, NoSuchObjectException
+from skyplane.obj_store.object_store_interface import ObjectStoreInterface
+from skyplane.exceptions import NoSuchObjectException
 from skyplane.replicate.profiler import status_df_to_traceevent
 from skyplane.replicate.replication_plan import ReplicationJob, ReplicationTopology, ReplicationTopologyGateway
 from skyplane.utils import logger

--- a/tests/integration/cp.py
+++ b/tests/integration/cp.py
@@ -16,8 +16,8 @@ def setup_buckets(src_region, dest_region, n_files=1, file_size_mb=1):
     logger.debug(f"creating buckets {src_bucket_name} and {dest_bucket_name}")
     src_interface = ObjectStoreInterface.create(src_region, src_bucket_name)
     dest_interface = ObjectStoreInterface.create(dest_region, dest_bucket_name)
-    src_interface.create_bucket()
-    dest_interface.create_bucket()
+    src_interface.create_bucket(src_zone)
+    dest_interface.create_bucket(dest_zone)
 
     src_prefix = f"src_{uuid.uuid4()}"
     dest_prefix = f"dest_{uuid.uuid4()}"

--- a/tests/interface_util.py
+++ b/tests/interface_util.py
@@ -13,7 +13,7 @@ from skyplane.utils import logger
 def interface_test_framework(region, bucket, multipart: bool, test_delete_bucket: bool = False):
     logger.info("creating interfaces...")
     interface = ObjectStoreInterface.create(region, bucket)
-    interface.create_bucket()
+    interface.create_bucket(region.split(":")[1])
     assert interface.bucket_exists()
     debug_time = lambda n, s, e: logger.info(f"{n} {s}MB in {round(e, 2)}s ({round(s / e, 2)}MB/s)")
 

--- a/tests/unit_aws/test_s3_interface.py
+++ b/tests/unit_aws/test_s3_interface.py
@@ -10,3 +10,10 @@ def test_aws_singlepart():
 def test_aws_multipart():
     logger.warning("Multipart tests disabled!")
     # assert test_interface("aws: us-east-1", "sky-us-east-1", True)
+
+
+if __name__ == "__main__":
+    test_aws_singlepart()
+    test_aws_multipart()
+    logger.info("All tests passed!")
+    exit(0)


### PR DESCRIPTION
Object store interfaces have many issues that I am cleaning up:
* Better handling of region resolution. Instead of passing it directly, the region is queried from the object store.
* Explicit specification of bucket location when creating a bucket
* Break AzureInferface into AzureStorageAccountInterface and AzureBlobInterface