### PR TITLE
Change multipart_min_threshold_mb from 64 to 128

### DIFF
--- a/skyplane/config.py
+++ b/skyplane/config.py
@@ -34,7 +34,7 @@ _DEFAULT_FLAGS = {
     "encrypt_socket_tls": False,
     "verify_checksums": True,
     "multipart_enabled": True,
-    "multipart_min_threshold_mb": 64,
+    "multipart_min_threshold_mb": 128,
     "multipart_min_size_mb": 8,
     "multipart_max_chunks": 9990,  # AWS limit is 10k chunks
     "num_connections": 32,


### PR DESCRIPTION
For fake_imagenet especially, the training batches are of size 67 MB which is slightly larger than multipart_min_threshold. Changing the threshold to 128 should fix this issue #499.