### PR TITLE
Azure Authentication 2.0 (User Managed Identities)

### DIFF
--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -12,7 +12,6 @@ import skyplane.cli
 import skyplane.cli.usage.definitions
 import skyplane.cli.usage.client
 from skyplane.cli.usage.client import UsageClient, UsageStatsStatus
-from skyplane.obj_store.azure_storage_account_interface import AzureStorageAccountInterface
 from skyplane.replicate.replicator_client import ReplicatorClient
 
 import typer

--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -12,6 +12,7 @@ import skyplane.cli
 import skyplane.cli.usage.definitions
 import skyplane.cli.usage.client
 from skyplane.cli.usage.client import UsageClient, UsageStatsStatus
+from skyplane.obj_store.azure_storage_account_interface import AzureStorageAccountInterface
 from skyplane.replicate.replicator_client import ReplicatorClient
 
 import typer

--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -133,9 +133,6 @@ def generate_full_transferobjlist(
     source_iface = ObjectStoreInterface.create(source_region, source_bucket)
     dest_iface = ObjectStoreInterface.create(dest_region, dest_bucket)
 
-    # acct_iface = AzureStorageAccountInterface("skyplaneasim").storage_account_obj()
-    # breakpoint()
-    # ensure buckets exist
     if not source_iface.bucket_exists():
         raise exceptions.MissingBucketException(f"Source bucket {source_bucket} does not exist")
     if not dest_iface.bucket_exists():

--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -290,7 +290,7 @@ def launch_replication_job(
         )
         total_bytes = sum([chunk_req.chunk.chunk_length_bytes for chunk_req in job.chunk_requests])
         console.print(f":rocket: [bold blue]{total_bytes / GB:.2f}GB transfer job launched[/bold blue]")
-        
+
         stats = rc.monitor_transfer(
             job,
             show_spinner=True,

--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -11,6 +11,7 @@ from rich import print as rprint
 
 from skyplane import exceptions, GB, format_bytes, gateway_docker_image, skyplane_root
 from skyplane.compute.cloud_providers import CloudProvider
+from skyplane.obj_store.azure_storage_account_interface import AzureStorageAccountInterface
 from skyplane.obj_store.object_store_interface import ObjectStoreInterface, ObjectStoreObject
 from skyplane.obj_store.s3_interface import S3Object
 from skyplane.obj_store.gcs_interface import GCSObject
@@ -132,6 +133,8 @@ def generate_full_transferobjlist(
     source_iface = ObjectStoreInterface.create(source_region, source_bucket)
     dest_iface = ObjectStoreInterface.create(dest_region, dest_bucket)
 
+    # acct_iface = AzureStorageAccountInterface("skyplaneasim").storage_account_obj()
+    # breakpoint()
     # ensure buckets exist
     if not source_iface.bucket_exists():
         raise exceptions.MissingBucketException(f"Source bucket {source_bucket} does not exist")
@@ -287,11 +290,7 @@ def launch_replication_job(
         )
         total_bytes = sum([chunk_req.chunk.chunk_length_bytes for chunk_req in job.chunk_requests])
         console.print(f":rocket: [bold blue]{total_bytes / GB:.2f}GB transfer job launched[/bold blue]")
-        if topo.source_region().split(":")[0] == "azure" or topo.sink_region().split(":")[0] == "azure":
-            typer.secho(
-                f"Warning: For Azure transfers, your transfer may block for up to 120s waiting for role assignments to propagate. See issue #355.",
-                fg="yellow",
-            )
+        
         stats = rc.monitor_transfer(
             job,
             show_spinner=True,

--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -11,7 +11,6 @@ from rich import print as rprint
 
 from skyplane import exceptions, GB, format_bytes, gateway_docker_image, skyplane_root
 from skyplane.compute.cloud_providers import CloudProvider
-from skyplane.obj_store.azure_storage_account_interface import AzureStorageAccountInterface
 from skyplane.obj_store.object_store_interface import ObjectStoreInterface, ObjectStoreObject
 from skyplane.obj_store.s3_interface import S3Object
 from skyplane.obj_store.gcs_interface import GCSObject

--- a/skyplane/cli/cli_impl/init.py
+++ b/skyplane/cli/cli_impl/init.py
@@ -169,7 +169,7 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
                     typer.secho(f"    stderr: {err.decode('utf-8')}", fg="red", err=True)
                     return clear_azure_config(config)
         typer.secho(
-            f"    Azure managed identity created successfully! To delete it, run `az identity delete -n skyplane -g skyplane`.",
+            f"    Azure managed identity created successfully! To delete it, run `az identity delete -n skyplane_umi -g skyplane`.",
             fg="green",
         )
 
@@ -186,7 +186,7 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
                 auth.wait_for_valid_token()
         except TimeoutError:
             typer.secho(
-                "    The Azure service principal doesn't have access to your storage accounts. Please ensure you have granted the service principal the Storage Blob Data Contributor and Storage Account Contributor roles.",
+                "    The Azure managed identity doesn't have access to your storage accounts. Please ensure you have granted the managed identity the Storage Blob Data Contributor and Storage Account Contributor roles.",
                 fg="red",
                 err=True,
             )

--- a/skyplane/cli/cli_impl/init.py
+++ b/skyplane/cli/cli_impl/init.py
@@ -175,22 +175,22 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
 
         config.azure_enabled = True
         auth = AzureAuthentication(config=config)
-        try:
-            with Progress(
-                TextColumn("    "),
-                SpinnerColumn(),
-                TextColumn("Waiting for Azure roles to propagate{task.description}"),
-                transient=True,
-            ) as progress:
-                progress.add_task("", total=None)
-                auth.wait_for_valid_token()
-        except TimeoutError:
-            typer.secho(
-                "    The Azure managed identity doesn't have access to your storage accounts. Please ensure you have granted the managed identity the Storage Blob Data Contributor and Storage Account Contributor roles.",
-                fg="red",
-                err=True,
-            )
-            return clear_azure_config(config)
+        # try:
+        #     with Progress(
+        #         TextColumn("    "),
+        #         SpinnerColumn(),
+        #         TextColumn("Waiting for Azure roles to propagate{task.description}"),
+        #         transient=True,
+        #     ) as progress:
+        #         progress.add_task("", total=None)
+        #         auth.wait_for_valid_token()
+        # except TimeoutError:
+        #     typer.secho(
+        #         "    The Azure managed identity doesn't have access to your storage accounts. Please ensure you have granted the managed identity the Storage Blob Data Contributor and Storage Account Contributor roles.",
+        #         fg="red",
+        #         err=True,
+        #     )
+        #     return clear_azure_config(config)
         with Progress(
             TextColumn("    "),
             SpinnerColumn(),

--- a/skyplane/cli/cli_impl/init.py
+++ b/skyplane/cli/cli_impl/init.py
@@ -69,7 +69,7 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
         return [
             "az role assignment create --role".split(" ")
             + [role]
-            + f"--assignee-object-id {principal_id} --scope /subscriptions/{subscription_id}".split(" ")
+            + f"--assignee-object-id {principal_id} --assignee-principal-type ServicePrincipal --scope /subscriptions/{subscription_id}".split(" ")
             for role in roles
         ]
 

--- a/skyplane/cli/cli_impl/init.py
+++ b/skyplane/cli/cli_impl/init.py
@@ -15,6 +15,7 @@ from skyplane.compute.gcp.gcp_auth import GCPAuthentication
 
 from skyplane.compute.azure.azure_server import AzureServer
 
+
 def load_aws_config(config: SkyplaneConfig, non_interactive: bool = False) -> SkyplaneConfig:
     if non_interactive or typer.confirm("    Do you want to configure AWS support in Skyplane?", default=True):
         # get AWS credentials from boto3
@@ -69,7 +70,9 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
         return [
             "az role assignment create --role".split(" ")
             + [role]
-            + f"--assignee-object-id {principal_id} --assignee-principal-type ServicePrincipal --scope /subscriptions/{subscription_id}".split(" ")
+            + f"--assignee-object-id {principal_id} --assignee-principal-type ServicePrincipal --scope /subscriptions/{subscription_id}".split(
+                " "
+            )
             for role in roles
         ]
 
@@ -95,7 +98,7 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
             "subscription_id": os.environ.get("AZURE_SUBSCRIPTION_ID")
             or config.azure_subscription_id
             or AzureAuthentication.infer_subscription_id(),
-            "resource_group": os.environ.get("AZURE_RESOURCE_GROUP") or AzureServer.resource_group_name
+            "resource_group": os.environ.get("AZURE_RESOURCE_GROUP") or AzureServer.resource_group_name,
         }
         create_rg_cmd = "az group create -l westus2 -n skyplane"
         out, err = subprocess.Popen(create_rg_cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
@@ -104,7 +107,7 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
             typer.secho(f"    stdout: {out.decode('utf-8')}", fg="red", err=True)
             typer.secho(f"    stderr: {err.decode('utf-8')}", fg="red", err=True)
             return clear_azure_config(config)
-        
+
         config.azure_subscription_id = typer.prompt(
             "    Which Azure subscription ID do you want to use?", default=defaults["subscription_id"]
         )
@@ -137,11 +140,7 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
             config.azure_client_id = identity_json["clientId"]
             config.azure_principal_id = identity_json["principalId"]
 
-        if (
-            not config.azure_client_id
-            or not config.azure_principal_id
-            or not config.azure_subscription_id
-        ):
+        if not config.azure_client_id or not config.azure_principal_id or not config.azure_subscription_id:
             typer.secho("    Azure credentials not configured correctly, disabling Azure support.", fg="red", err=True)
             return clear_azure_config(config)
 

--- a/skyplane/cli/cli_impl/init.py
+++ b/skyplane/cli/cli_impl/init.py
@@ -13,8 +13,7 @@ from skyplane.compute.aws.aws_auth import AWSAuthentication
 from skyplane.compute.azure.azure_auth import AzureAuthentication
 from skyplane.compute.gcp.gcp_auth import GCPAuthentication
 
-from skylark.skyplane.compute.azure.azure_server import AzureServer
-
+from skyplane.compute.azure.azure_server import AzureServer
 
 def load_aws_config(config: SkyplaneConfig, non_interactive: bool = False) -> SkyplaneConfig:
     if non_interactive or typer.confirm("    Do you want to configure AWS support in Skyplane?", default=True):
@@ -96,7 +95,7 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
             "subscription_id": os.environ.get("AZURE_SUBSCRIPTION_ID")
             or config.azure_subscription_id
             or AzureAuthentication.infer_subscription_id(),
-            "resource_group": os.environ.get("AZURE_RESOURCE_GROUP") or config.azure_resource_group or AzureServer.resource_group_name
+            "resource_group": os.environ.get("AZURE_RESOURCE_GROUP") or AzureServer.resource_group_name
         }
         create_rg_cmd = "az group create -l westus2 -n skyplane"
         out, err = subprocess.Popen(create_rg_cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()

--- a/skyplane/cli/cli_impl/init.py
+++ b/skyplane/cli/cli_impl/init.py
@@ -179,7 +179,7 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
             with Progress(
                 TextColumn("    "),
                 SpinnerColumn(),
-                TextColumn("Waiting for Azure client secret to propagate{task.description}"),
+                TextColumn("Waiting for Azure roles to propagate{task.description}"),
                 transient=True,
             ) as progress:
                 progress.add_task("", total=None)

--- a/skyplane/cli/cli_impl/init.py
+++ b/skyplane/cli/cli_impl/init.py
@@ -174,22 +174,6 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
 
         config.azure_enabled = True
         auth = AzureAuthentication(config=config)
-        # try:
-        #     with Progress(
-        #         TextColumn("    "),
-        #         SpinnerColumn(),
-        #         TextColumn("Waiting for Azure roles to propagate{task.description}"),
-        #         transient=True,
-        #     ) as progress:
-        #         progress.add_task("", total=None)
-        #         auth.wait_for_valid_token()
-        # except TimeoutError:
-        #     typer.secho(
-        #         "    The Azure managed identity doesn't have access to your storage accounts. Please ensure you have granted the managed identity the Storage Blob Data Contributor and Storage Account Contributor roles.",
-        #         fg="red",
-        #         err=True,
-        #     )
-        #     return clear_azure_config(config)
         with Progress(
             TextColumn("    "),
             SpinnerColumn(),

--- a/skyplane/cli/cli_impl/init.py
+++ b/skyplane/cli/cli_impl/init.py
@@ -169,7 +169,7 @@ def load_azure_config(config: SkyplaneConfig, force_init: bool = False, non_inte
                     typer.secho(f"    stderr: {err.decode('utf-8')}", fg="red", err=True)
                     return clear_azure_config(config)
         typer.secho(
-            f"    Azure managed identity created successfully! To delete it, run `az identity delete -n skyplane -g {config.azure_resource_group}`.",
+            f"    Azure managed identity created successfully! To delete it, run `az identity delete -n skyplane -g skyplane`.",
             fg="green",
         )
 

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 from typing import Dict, List, Optional
 
-from azure.identity import ClientSecretCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.mgmt.authorization import AuthorizationManagementClient
 from azure.mgmt.storage import StorageManagementClient
 from azure.storage.blob import BlobServiceClient, ContainerClient
@@ -43,11 +43,13 @@ class AzureAuthentication:
         self._credential = None
 
     @property
-    def credential(self) -> ClientSecretCredential:
+    def credential(self) -> DefaultAzureCredential:
         if self._credential is None:
-            self._credential = ClientSecretCredential(
-                tenant_id=self.config.azure_tenant_id, client_id=self.config.azure_client_id, client_secret=self.config.azure_client_secret
-            )
+            if is_gateway_env:
+                return ManagedIdentityCredential(self.config.azure_client_id)
+            else:
+                return DefaultAzureCredential(managed_identity_client_id=self.config.azure_client_id, exclude_powershell_credential=True,
+            exclude_visual_studio_code_credential=True)
         return self._credential
 
     @property

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -53,7 +53,7 @@ class AzureAuthentication:
                 return ManagedIdentityCredential(self.config.azure_client_id)
             else:
                 print("Configured DefaultAzureCredential with UMI client id: ", self.config.azure_client_id)
-                if (query_which_cloud() is not "azure"):
+                if query_which_cloud() != "azure":
                     return DefaultAzureCredential(exclude_managed_identity_credential=True, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)
                 else:
                     return DefaultAzureCredential(managed_identity_client_id=self.config.azure_client_id, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -47,8 +47,10 @@ class AzureAuthentication:
     def credential(self) -> DefaultAzureCredential:
         if self._credential is None:
             if is_gateway_env:
+                print("Configured managed identity credential.")
                 return ManagedIdentityCredential(self.config.azure_client_id)
             else:
+                print("Configured DefaultAzureCredential with UMI client id: ", self.config.azure_client_id)
                 return DefaultAzureCredential(managed_identity_client_id=self.config.azure_client_id, exclude_powershell_credential=True,
             exclude_visual_studio_code_credential=True)
         return self._credential
@@ -73,9 +75,6 @@ class AzureAuthentication:
         wait_for(try_login, desc="Wait for Azure roles to propagate", timeout=200)
 
     def save_region_config(self):
-        os.environ["AZURE_CLIENT_ID"] = self.config.azure_client_id
-        os.environ["AZURE_SUBSCRIPTION_ID"] = self.config.azure_subscription_id
-
         if self.config.azure_enabled == False:
             self.clear_region_config()
             return

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -69,7 +69,7 @@ class AzureAuthentication:
             except:
                 return False
 
-        wait_for(try_login, desc="Wait for Azure client secret to register", timeout=15)
+        wait_for(try_login, desc="Wait for Azure roles to propagate", timeout=200)
 
     def save_region_config(self):
         if self.config.azure_enabled == False:

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -16,6 +16,8 @@ from skyplane import is_gateway_env
 from skyplane.config import SkyplaneConfig
 from skyplane.utils.fn import do_parallel, wait_for
 
+from skylark.skyplane.compute.const_cmds import query_which_cloud
+
 # optional imports due to large package size
 try:
     from azure.mgmt.network import NetworkManagementClient
@@ -51,8 +53,10 @@ class AzureAuthentication:
                 return ManagedIdentityCredential(self.config.azure_client_id)
             else:
                 print("Configured DefaultAzureCredential with UMI client id: ", self.config.azure_client_id)
-                return DefaultAzureCredential(managed_identity_client_id=self.config.azure_client_id, exclude_powershell_credential=True,
-            exclude_visual_studio_code_credential=True)
+                if (query_which_cloud() is not "azure"):
+                    return DefaultAzureCredential(exclude_managed_identity_credential=True, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)
+                else:
+                    return DefaultAzureCredential(managed_identity_client_id=self.config.azure_client_id, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)
         return self._credential
 
     @property

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -109,7 +109,7 @@ class AzureAuthentication:
             region_list,
             spinner=False,
             spinner_persist=False,
-            desc="Query available VM SKUs from each enabled Azure region (est. time: ~1 minute",
+            desc="Query available VM SKUs from each enabled Azure region (est. time: ~1 minute)",
             n=8,
         )
         region_sku = dict()

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -52,7 +52,6 @@ class AzureAuthentication:
                 print("Configured managed identity credential.")
                 return ManagedIdentityCredential(self.config.azure_client_id)
             else:
-                print("Configured DefaultAzureCredential with UMI client id: ", self.config.azure_client_id)
                 if query_which_cloud() != "azure":
                     return DefaultAzureCredential(exclude_managed_identity_credential=True, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)
                 else:
@@ -97,7 +96,7 @@ class AzureAuthentication:
             return set(valid_skus)
 
         result = do_parallel(
-            get_skus, region_list, spinner=False, spinner_persist=False, desc="Query available VM SKUs from each enabled Azure region", n=8
+            get_skus, region_list, spinner=False, spinner_persist=False, desc="Query available VM SKUs from each enabled Azure region (est. time: ~1 minute", n=8
         )
         region_sku = dict()
         for region, skus in result:

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -73,6 +73,9 @@ class AzureAuthentication:
         wait_for(try_login, desc="Wait for Azure roles to propagate", timeout=200)
 
     def save_region_config(self):
+        os.environ["AZURE_CLIENT_ID"] = self.config.azure_client_id
+        os.environ["AZURE_SUBSCRIPTION_ID"] = self.config.azure_subscription_id
+
         if self.config.azure_enabled == False:
             self.clear_region_config()
             return

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -53,9 +53,18 @@ class AzureAuthentication:
                 return ManagedIdentityCredential(client_id=self.config.azure_client_id)
             else:
                 if query_which_cloud() != "azure":
-                    return DefaultAzureCredential(exclude_environment_credential=True, exclude_managed_identity_credential=True, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)
+                    return DefaultAzureCredential(
+                        exclude_environment_credential=True,
+                        exclude_managed_identity_credential=True,
+                        exclude_powershell_credential=True,
+                        exclude_visual_studio_code_credential=True,
+                    )
                 else:
-                    return DefaultAzureCredential(managed_identity_client_id=self.config.azure_client_id, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)
+                    return DefaultAzureCredential(
+                        managed_identity_client_id=self.config.azure_client_id,
+                        exclude_powershell_credential=True,
+                        exclude_visual_studio_code_credential=True,
+                    )
         return self._credential
 
     @property
@@ -96,7 +105,12 @@ class AzureAuthentication:
             return set(valid_skus)
 
         result = do_parallel(
-            get_skus, region_list, spinner=False, spinner_persist=False, desc="Query available VM SKUs from each enabled Azure region (est. time: ~1 minute", n=8
+            get_skus,
+            region_list,
+            spinner=False,
+            spinner_persist=False,
+            desc="Query available VM SKUs from each enabled Azure region (est. time: ~1 minute",
+            n=8,
         )
         region_sku = dict()
         for region, skus in result:

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -12,6 +12,7 @@ from azure.storage.blob import BlobServiceClient, ContainerClient
 from skyplane import azure_config_path
 from skyplane import azure_sku_path
 from skyplane import config_path
+from skyplane import is_gateway_env
 from skyplane.config import SkyplaneConfig
 from skyplane.utils.fn import do_parallel, wait_for
 

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -16,7 +16,7 @@ from skyplane import is_gateway_env
 from skyplane.config import SkyplaneConfig
 from skyplane.utils.fn import do_parallel, wait_for
 
-from skylark.skyplane.compute.const_cmds import query_which_cloud
+from skyplane.compute.const_cmds import query_which_cloud
 
 # optional imports due to large package size
 try:

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -50,10 +50,10 @@ class AzureAuthentication:
         if self._credential is None:
             if is_gateway_env:
                 print("Configured managed identity credential.")
-                return ManagedIdentityCredential(self.config.azure_client_id)
+                return ManagedIdentityCredential(client_id=self.config.azure_client_id)
             else:
                 if query_which_cloud() != "azure":
-                    return DefaultAzureCredential(exclude_managed_identity_credential=True, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)
+                    return DefaultAzureCredential(exclude_environment_credential=True, exclude_managed_identity_credential=True, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)
                 else:
                     return DefaultAzureCredential(managed_identity_client_id=self.config.azure_client_id, exclude_powershell_credential=True, exclude_visual_studio_code_credential=True)
         return self._credential

--- a/skyplane/compute/azure/azure_cloud_provider.py
+++ b/skyplane/compute/azure/azure_cloud_provider.py
@@ -363,15 +363,17 @@ class AzureCloudProvider(CloudProvider):
                             "network_profile": {"network_interfaces": [{"id": nic_result.id}]},
                             # give VM managed identity w/ user assigned identity
                             "identity": {
-                                "type": ResourceIdentityType.user_assigned, 
-                                "user_assigned_identities":  [{
-                                    # zero-documentation.. *sigh*
-                                    "key": f"/subscriptions/{cloud_config.azure_subscription_id}/resourceGroups/skyplane/providers/Microsoft.ManagedIdentity/userAssignedIdentities/skyplane_umi",
-                                    "value": {
-                                        "principal_id": cloud_config.azure_principal_id,
-                                        "client_id": cloud_config.azure_client_id
+                                "type": ResourceIdentityType.user_assigned,
+                                "user_assigned_identities": [
+                                    {
+                                        # zero-documentation.. *sigh*
+                                        "key": f"/subscriptions/{cloud_config.azure_subscription_id}/resourceGroups/skyplane/providers/Microsoft.ManagedIdentity/userAssignedIdentities/skyplane_umi",
+                                        "value": {
+                                            "principal_id": cloud_config.azure_principal_id,
+                                            "client_id": cloud_config.azure_client_id,
+                                        },
                                     }
-                                }]
+                                ],
                             },
                         },
                     )
@@ -384,7 +386,7 @@ class AzureCloudProvider(CloudProvider):
                         raise exceptions.InsufficientVCPUException(f"Got QuotaExceeded error in Azure region {location}") from e
                     else:
                         raise
-        
+
         server = AzureServer(name)
         server.wait_for_ssh_ready()
         return server

--- a/skyplane/compute/azure/azure_cloud_provider.py
+++ b/skyplane/compute/azure/azure_cloud_provider.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import uuid
@@ -14,7 +15,7 @@ with warnings.catch_warnings():
 from azure.mgmt.compute.models import ResourceIdentityType
 from azure.core.exceptions import HttpResponseError
 
-from skyplane import exceptions, key_root
+from skyplane import cloud_config, exceptions, key_root
 from skyplane.compute.azure.azure_auth import AzureAuthentication
 from skyplane.compute.azure.azure_server import AzureServer
 from skyplane.compute.cloud_providers import CloudProvider
@@ -360,8 +361,18 @@ class AzureCloudProvider(CloudProvider):
                                 },
                             },
                             "network_profile": {"network_interfaces": [{"id": nic_result.id}]},
-                            # give VM managed identity w/ system assigned identity
-                            "identity": {"type": ResourceIdentityType.system_assigned},
+                            # give VM managed identity w/ user assigned identity
+                            "identity": {
+                                "type": ResourceIdentityType.user_assigned, 
+                                "user_assigned_identities":  [{
+                                    # zero-documentation.. *sigh*
+                                    "key": f"/subscriptions/{cloud_config.azure_subscription_id}/resourceGroups/skyplane/providers/Microsoft.ManagedIdentity/userAssignedIdentities/skyplane_umi",
+                                    "value": {
+                                        "principal_id": cloud_config.azure_principal_id,
+                                        "client_id": cloud_config.azure_client_id
+                                    }
+                                }]
+                            },
                         },
                     )
                     vm_result = poller.result()
@@ -373,7 +384,7 @@ class AzureCloudProvider(CloudProvider):
                         raise exceptions.InsufficientVCPUException(f"Got QuotaExceeded error in Azure region {location}") from e
                     else:
                         raise
-
+        
         server = AzureServer(name)
         server.wait_for_ssh_ready()
         return server

--- a/skyplane/compute/azure/azure_cloud_provider.py
+++ b/skyplane/compute/azure/azure_cloud_provider.py
@@ -366,7 +366,7 @@ class AzureCloudProvider(CloudProvider):
                                 "type": ResourceIdentityType.user_assigned,
                                 "user_assigned_identities": [
                                     {
-                                        # zero-documentation.. *sigh*
+                                        # code from: https://github.com/ray-project/ray/pull/7080/files#diff-0f1bb1da82d112b850a85c1b7b1876e50efd5a7400c62a5c4de334f494d3bf46R222-R233
                                         "key": f"/subscriptions/{cloud_config.azure_subscription_id}/resourceGroups/skyplane/providers/Microsoft.ManagedIdentity/userAssignedIdentities/skyplane_umi",
                                         "value": {
                                             "principal_id": cloud_config.azure_principal_id,

--- a/skyplane/compute/azure/azure_server.py
+++ b/skyplane/compute/azure/azure_server.py
@@ -147,14 +147,8 @@ class AzureServer(Server):
         compute_client = self.auth.get_compute_client()
         network_client = self.auth.get_network_client()
 
-        # remove any role assignments to the VM's system assigned identity
         auth_client = self.auth.get_authorization_client()
         vm = self.get_virtual_machine()
-        
-        for identity in vm.identity.user_assigned_identities.values():
-            for assignment in auth_client.role_assignments.list(filter="principalId eq '{}'".format(identity.principal_id)):
-                logger.fs.debug(f"Deleting role assignment {assignment.name}")
-                auth_client.role_assignments.delete(scope=assignment.scope, role_assignment_name=assignment.name)
 
         vm_poller = compute_client.virtual_machines.begin_delete(AzureServer.resource_group_name, self.vm_name(self.name))
         _ = vm_poller.result()

--- a/skyplane/config.py
+++ b/skyplane/config.py
@@ -67,6 +67,7 @@ class SkyplaneConfig:
     azure_enabled: bool
     gcp_enabled: bool
     anon_clientid: Optional[str] = None
+    azure_principal_id: Optional[str] = None
     azure_subscription_id: Optional[str] = None
     azure_tenant_id: Optional[str] = None
     azure_client_id: Optional[str] = None
@@ -105,6 +106,7 @@ class SkyplaneConfig:
         azure_tenant_id = None
         azure_client_id = None
         azure_client_secret = None
+        azure_principal_id = None
         if "azure" in config:
             if "azure_enabled" in config["azure"]:
                 azure_enabled = config.getboolean("azure", "azure_enabled")
@@ -116,6 +118,8 @@ class SkyplaneConfig:
                 azure_client_id = config.get("azure", "client_id")
             if "client_secret" in config["azure"]:
                 azure_client_secret = config.get("azure", "client_secret")
+            if "principal_id" in config["azure"]:
+                azure_principal_id = config.get("azure", "principal_id")
 
         gcp_enabled = False
         gcp_project_id = None
@@ -130,6 +134,7 @@ class SkyplaneConfig:
             azure_enabled=azure_enabled,
             gcp_enabled=gcp_enabled,
             anon_clientid=anon_clientid,
+            azure_principal_id=azure_principal_id,
             azure_subscription_id=azure_subscription_id,
             azure_tenant_id=azure_tenant_id,
             azure_client_id=azure_client_id,
@@ -166,6 +171,8 @@ class SkyplaneConfig:
             config.set("azure", "client_id", self.azure_client_id)
         if self.azure_client_secret:
             config.set("azure", "client_secret", self.azure_client_secret)
+        if self.azure_principal_id:
+            config.set("azure", "principal_id", self.azure_principal_id)
 
         if "gcp" not in config:
             config.add_section("gcp")


### PR DESCRIPTION
Currently, we use service principals and client secret for Azure authentication. This is not ideal, as many users do not have the admin privileges required to create a service principal within their subscription, especially if they are working within an organization. Instead, we opt to use [user managed identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview), and remove the need for client secrets and service principals.

We create a UMI upon skyplane init, and assign it the necessary roles. This identity will persist until manually deleted and is assigned to created VMs on transfers.