### PR TITLE
[CI] Run integration test nightly

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,5 +1,8 @@
 name: integration-test
-on: workflow_dispatch
+on:
+  schedule:
+    - cron: '9 23 * * *'
+  workflow_dispatch:
 concurrency: integration-test
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Currently integration tests run on workflow_dispatch; this PR adds support to run integration tests nightly.