### PR TITLE
Fix flaky S3 test by setting default boto3 region

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,6 +60,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           poetry run skyplane init -y --disable-config-azure --disable-config-gcp
           poetry run pytest -s tests/unit_aws

--- a/skyplane/compute/server.py
+++ b/skyplane/compute/server.py
@@ -311,7 +311,7 @@ class Server:
             self.upload_file(os.path.expanduser(f"{key_root}/gcp/{service_key_file}"), f"/tmp/{service_key_file}")
             docker_envs["GCP_SERVICE_ACCOUNT_FILE"] = f"/pkg/data/{service_key_file}"
             docker_run_flags += f" -v /tmp/{service_key_file}:/pkg/data/{service_key_file}"
-        
+
         # set default region for boto3 on AWS
         if self.provider == "aws":
             docker_envs["AWS_DEFAULT_REGION"] = self.region_tag.split(":")[1]

--- a/skyplane/compute/server.py
+++ b/skyplane/compute/server.py
@@ -311,6 +311,10 @@ class Server:
             self.upload_file(os.path.expanduser(f"{key_root}/gcp/{service_key_file}"), f"/tmp/{service_key_file}")
             docker_envs["GCP_SERVICE_ACCOUNT_FILE"] = f"/pkg/data/{service_key_file}"
             docker_run_flags += f" -v /tmp/{service_key_file}:/pkg/data/{service_key_file}"
+        
+        # set default region for boto3 on AWS
+        if self.provider == "aws":
+            docker_envs["AWS_DEFAULT_REGION"] = self.region_tag.split(":")[1]
 
         # copy E2EE keys
         if e2ee_key_bytes is not None:

--- a/skyplane/obj_store/s3_interface.py
+++ b/skyplane/obj_store/s3_interface.py
@@ -48,7 +48,7 @@ class S3Interface(ObjectStoreInterface):
         return self.auth.get_boto3_client("s3", region)
 
     def bucket_exists(self):
-        s3_client = self._s3_client("us-east-1")
+        s3_client = self._s3_client()
         try:
             s3_client.list_objects_v2(Bucket=self.bucket_name, MaxKeys=1)  # list one object to check if bucket exists
             return True
@@ -66,24 +66,24 @@ class S3Interface(ObjectStoreInterface):
                 s3_client.create_bucket(Bucket=self.bucket_name, CreateBucketConfiguration={"LocationConstraint": aws_region})
 
     def delete_bucket(self):
-        self._s3_client("us-east-1").delete_bucket(Bucket=self.bucket_name)
+        self._s3_client().delete_bucket(Bucket=self.bucket_name)
 
     def list_objects(self, prefix="") -> Iterator[S3Object]:
-        paginator = self._s3_client("us-east-1").get_paginator("list_objects_v2")
+        paginator = self._s3_client().get_paginator("list_objects_v2")
         page_iterator = paginator.paginate(Bucket=self.bucket_name, Prefix=prefix)
         for page in page_iterator:
             for obj in page.get("Contents", []):
                 yield S3Object("aws", self.bucket_name, obj["Key"], obj["Size"], obj["LastModified"])
 
     def delete_objects(self, keys: List[str]):
-        s3_client = self._s3_client("us-east-1")
+        s3_client = self._s3_client()
         while keys:
             batch, keys = keys[:1000], keys[1000:]  # take up to 1000 keys at a time
             s3_client.delete_objects(Bucket=self.bucket_name, Delete={"Objects": [{"Key": k} for k in batch]})
 
     @lru_cache(maxsize=1024)
     def get_obj_metadata(self, obj_name):
-        s3_client = self._s3_client("us-east-1")
+        s3_client = self._s3_client()
         try:
             return s3_client.head_object(Bucket=self.bucket_name, Key=str(obj_name))
         except botocore.exceptions.ClientError as e:
@@ -113,7 +113,7 @@ class S3Interface(ObjectStoreInterface):
         write_block_size=2**16,
     ) -> Optional[bytes]:
         src_object_name, dst_file_path = str(src_object_name), str(dst_file_path)
-        s3_client = self._s3_client("us-east-1")
+        s3_client = self._s3_client()
         assert len(src_object_name) > 0, f"Source object name must be non-empty: '{src_object_name}'"
 
         if size_bytes:
@@ -140,7 +140,7 @@ class S3Interface(ObjectStoreInterface):
 
     def upload_object(self, src_file_path, dst_object_name, part_number=None, upload_id=None, check_md5=None):
         dst_object_name, src_file_path = str(dst_object_name), str(src_file_path)
-        s3_client = self._s3_client("us-east-1")
+        s3_client = self._s3_client()
         assert len(dst_object_name) > 0, f"Destination object name must be non-empty: '{dst_object_name}'"
         b64_md5sum = base64.b64encode(check_md5).decode("utf-8") if check_md5 else None
         checksum_args = dict(ContentMD5=b64_md5sum) if b64_md5sum else dict()
@@ -167,7 +167,7 @@ class S3Interface(ObjectStoreInterface):
     def initiate_multipart_upload(self, dst_object_name):
         # cannot infer content type here
         assert len(dst_object_name) > 0, f"Destination object name must be non-empty: '{dst_object_name}'"
-        s3_client = self._s3_client("us-east-1")
+        s3_client = self._s3_client()
         response = s3_client.create_multipart_upload(
             Bucket=self.bucket_name,
             Key=dst_object_name,
@@ -175,7 +175,7 @@ class S3Interface(ObjectStoreInterface):
         return response["UploadId"]
 
     def complete_multipart_upload(self, dst_object_name, upload_id):
-        s3_client = self._s3_client("us-east-1")
+        s3_client = self._s3_client()
 
         all_parts = []
         while True:

--- a/skyplane/obj_store/s3_interface.py
+++ b/skyplane/obj_store/s3_interface.py
@@ -48,7 +48,7 @@ class S3Interface(ObjectStoreInterface):
         return self.auth.get_boto3_client("s3", region)
 
     def bucket_exists(self):
-        s3_client = self._s3_client()
+        s3_client = self._s3_client("us-east-1")
         try:
             s3_client.list_objects_v2(Bucket=self.bucket_name, MaxKeys=1)  # list one object to check if bucket exists
             return True

--- a/tests/interface_util.py
+++ b/tests/interface_util.py
@@ -40,9 +40,8 @@ def interface_test_framework(region, bucket, multipart: bool, test_delete_bucket
             interface.download_object(obj_name, fpath, 0, file_size_mb * MB)
         else:
             interface.download_object(obj_name, fpath)
-        iface_size = interface.get_obj_size(obj_name)
         local_size = os.path.getsize(fpath)
-        assert iface_size == local_size, f"Object size mismatch: {iface_size} != {local_size}"
+        assert file_size_mb * MB == local_size, f"Object size mismatch: {file_size_mb * MB} != {local_size}"
 
         # check md5
         with open(fpath, "rb") as f:


### PR DESCRIPTION
The S3 test is flaky on main. This PR attempts to fix this test by setting the boto3 region explicitly.