### PR TITLE
[UX] Print better error message when transfer validation fails

### DIFF
--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -219,6 +219,13 @@ def cp(
                 except exceptions.TransferFailedException as e:
                     console.print(f"[bright_black]{traceback.format_exc()}[/bright_black]")
                     console.print(e.pretty_print_str())
+                    client = UsageClient()
+                    src_region_tag = provider_src + ":" + bucket_src
+                    dst_region_tag = provider_dst + ":" + bucket_dst
+                    error_dict = {"loc": "create_pairs", "message": str(e)[:150]}
+                    stats = client.make_error(src_region_tag, dst_region_tag, error_dict, args)
+                    destination = client.write_usage_data(stats)
+                    client.report_usage_data("error", stats, destination)
                     raise typer.Exit(1)
 
         client = UsageClient()
@@ -418,6 +425,13 @@ def sync(
                 except exceptions.TransferFailedException as e:
                     console.print(f"[bright_black]{traceback.format_exc()}[/bright_black]")
                     console.print(e.pretty_print_str())
+                    client = UsageClient()
+                    src_region_tag = provider_src + ":" + bucket_src
+                    dst_region_tag = provider_dst + ":" + bucket_dst
+                    error_dict = {"loc": "create_pairs", "message": str(e)[:150]}
+                    stats = client.make_error(src_region_tag, dst_region_tag, error_dict, args)
+                    destination = client.write_usage_data(stats)
+                    client.report_usage_data("error", stats, destination)
                     raise typer.Exit(1)
 
     client = UsageClient()

--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -219,6 +219,7 @@ def cp(
                 except exceptions.TransferFailedException as e:
                     console.print(f"[bright_black]{traceback.format_exc()}[/bright_black]")
                     console.print(e.pretty_print_str())
+
                     client = UsageClient()
                     src_region_tag = provider_src + ":" + bucket_src
                     dst_region_tag = provider_dst + ":" + bucket_dst
@@ -227,6 +228,12 @@ def cp(
                     destination = client.write_usage_data(stats)
                     client.report_usage_data("error", stats, destination)
                     raise typer.Exit(1)
+
+        if transfer_stats.monitor_status == "completed":
+            rprint(f"\n:white_check_mark: [bold green]Transfer completed successfully[/bold green]")
+            runtime_line = f"[white]Transfer runtime:[/white] [bright_black]{transfer_stats.total_runtime_s:.2f}s[/bright_black]"
+            throughput_line = f"[white]Throughput:[/white] [bright_black]{transfer_stats.throughput_gbits:.2f}Gbps[/bright_black]"
+            rprint(f"{runtime_line}, {throughput_line}")
 
         client = UsageClient()
         if client.enabled():
@@ -425,6 +432,7 @@ def sync(
                 except exceptions.TransferFailedException as e:
                     console.print(f"[bright_black]{traceback.format_exc()}[/bright_black]")
                     console.print(e.pretty_print_str())
+
                     client = UsageClient()
                     src_region_tag = provider_src + ":" + bucket_src
                     dst_region_tag = provider_dst + ":" + bucket_dst
@@ -433,6 +441,12 @@ def sync(
                     destination = client.write_usage_data(stats)
                     client.report_usage_data("error", stats, destination)
                     raise typer.Exit(1)
+
+    if transfer_stats.monitor_status == "completed":
+        rprint(f"\n:white_check_mark: [bold green]Transfer completed successfully[/bold green]")
+        runtime_line = f"[white]Transfer runtime:[/white] [bright_black]{transfer_stats.total_runtime_s:.2f}s[/bright_black]"
+        throughput_line = f"[white]Throughput:[/white] [bright_black]{transfer_stats.throughput_gbits:.2f}Gbps[/bright_black]"
+        rprint(f"{runtime_line}, {throughput_line}")
 
     client = UsageClient()
     if client.enabled():

--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -214,7 +214,12 @@ def cp(
             provider_dst = topo.sink_region().split(":")[0]
             with Progress(SpinnerColumn(), TextColumn("Verifying all files were copied{task.description}")) as progress:
                 progress.add_task("", total=None)
-                ReplicatorClient.verify_transfer_prefix(dest_prefix=path_dst, job=job)
+                try:
+                    ReplicatorClient.verify_transfer_prefix(dest_prefix=path_dst, job=job)
+                except exceptions.TransferFailedException as e:
+                    console.print(f"[bright_black]{traceback.format_exc()}[/bright_black]")
+                    console.print(e.pretty_print_str())
+                    raise typer.Exit(1)
 
         client = UsageClient()
         if client.enabled():
@@ -408,7 +413,12 @@ def sync(
         else:
             with Progress(SpinnerColumn(), TextColumn("Verifying all files were copied{task.description}"), transient=True) as progress:
                 progress.add_task("", total=None)
-                ReplicatorClient.verify_transfer_prefix(dest_prefix=path_dst, job=job)
+                try:
+                    ReplicatorClient.verify_transfer_prefix(dest_prefix=path_dst, job=job)
+                except exceptions.TransferFailedException as e:
+                    console.print(f"[bright_black]{traceback.format_exc()}[/bright_black]")
+                    console.print(e.pretty_print_str())
+                    raise typer.Exit(1)
 
     client = UsageClient()
     if client.enabled():

--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -376,10 +376,8 @@ def launch_replication_job(
             client.report_usage_data("error", err_stats, destination)
         raise typer.Exit(1)
     elif stats.monitor_status == "completed":
-        rprint(f"\n:white_check_mark: [bold green]Transfer completed successfully[/bold green]")
-        runtime_line = f"[white]Transfer runtime:[/white] [bright_black]{stats.total_runtime_s:.2f}s[/bright_black]"
-        throughput_line = f"[white]Throughput:[/white] [bright_black]{stats.throughput_gbits:.2f}Gbps[/bright_black]"
-        rprint(f"{runtime_line}, {throughput_line}")
+        # success message will be handled by the caller
+        pass
     else:
         rprint(f"\n:x: [bold red]Transfer failed[/bold red]")
         rprint(stats)

--- a/skyplane/exceptions.py
+++ b/skyplane/exceptions.py
@@ -41,7 +41,7 @@ class TransferFailedException(SkyplaneException):
     def pretty_print_str(self):
         err = f"[red][bold]:x: TransferFailedException:[/bold] {str(self)}[/red]"
         if self.failed_objects and len(self.failed_objects) > 0:
-            err += "\n[bold][red]The following objects were not found at the destination:[/red][/bold] " + str(self.failed_objects)
+            err += "\n[bold][red]Transfer failed. The following objects were not found at the destination:[/red][/bold] " + str(self.failed_objects)
         return err
 
 

--- a/skyplane/exceptions.py
+++ b/skyplane/exceptions.py
@@ -41,7 +41,7 @@ class TransferFailedException(SkyplaneException):
     def pretty_print_str(self):
         err = f"[red][bold]:x: TransferFailedException:[/bold] {str(self)}[/red]"
         if self.failed_objects and len(self.failed_objects) > 0:
-            err += "\n[bold][red]Failed objects:[/red][/bold] " + str(self.failed_objects)
+            err += "\n[bold][red]The following objects were not found at the destination:[/red][/bold] " + str(self.failed_objects)
         return err
 
 

--- a/skyplane/exceptions.py
+++ b/skyplane/exceptions.py
@@ -41,7 +41,9 @@ class TransferFailedException(SkyplaneException):
     def pretty_print_str(self):
         err = f"[red][bold]:x: TransferFailedException:[/bold] {str(self)}[/red]"
         if self.failed_objects and len(self.failed_objects) > 0:
-            err += "\n[bold][red]Transfer failed. The following objects were not found at the destination:[/red][/bold] " + str(self.failed_objects)
+            err += "\n[bold][red]Transfer failed. The following objects were not found at the destination:[/red][/bold] " + str(
+                self.failed_objects
+            )
         return err
 
 


### PR DESCRIPTION
Fixes #508 

TransferFailedException raised by ReplicatorClient.verify_transfer_prefix() will now be caught in both cp and sync, and a detailed transfer failed message will be printed.
<img width="1239" alt="transfer_failed" src="https://user-images.githubusercontent.com/7588789/189557755-e2a32f11-465b-4909-852d-97a51217556d.png">
