### PR TITLE
Small transfer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Skyplane is a tool for blazingly fast bulk data transfers in the cloud. Skyplane
 You can use Skyplane to transfer data: 
 * Between buckets within a cloud provider
 * Between object stores across multiple cloud providers
-* (experimental) Between local storage and cloud object stores
+* Between local storage and cloud object stores
 
 Skyplane currently only supports MacOS and Linux. For Windows, first [install Linux on Windows with WSL](https://docs.microsoft.com/en-us/windows/wsl/install) to run Skyplane.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,9 @@ Skyplane performs high-performance, cost-efficient, bulk data transfers by paral
 To learn about how Skyplane works, please see our talk here:
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/hOCrpcIBkAU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
+## On prem support
+Skyplane now supports local to cloud object store transfers. For this, Skyplane defaults to awscli (for AWS), and gsutil (for GCP). [Let us know](https://github.com/skyplane-project/skyplane/issues/545) if you would like to see on-prem support for Azure.
+
 ## Transfer Integrity and Checksumming
 Skyplane takes several steps to ensure the correctness of transfers. To ensure that data is transferred without corruption (e.g. bit flips or missing byte ranges), Skyplane will compute checksums for data at the source region and verify data matches the checksum before writing back to the destination region. To ensure that no files are dropped during the transfer, Skyplane will query the destination object store after a transfer and check all files were copied with the correct file size. To verify checksums for whole-file transfers, Skyplane computes MD5 hashes at the source region. Upon writing data at the destination, hashes are validated directly in the destintation object store. For multipart transfers, hashses are validated at the destination VM before writing to the object store.
 
@@ -36,4 +39,4 @@ While GCP VPCs are Global, in AWS for every region that is involved in a transfe
 Firewall support for Azure is in the roadmap. 
 
 ## Large Objects
-Skyplane breaks large objects into smaller sub-parts (currently AWS and GCP only) to improve transfer parallelism (also known as [striping](https://ieeexplore.ieee.org/document/1560006)). 
+Skyplane breaks large objects into smaller sub-parts (currently AWS and GCP only) to improve transfer parallelism (also known as [striping](https://ieeexplore.ieee.org/document/1560006)).

--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -144,7 +144,7 @@ def cp(
         typer.secho(f"Falling back to: {cmd}")
         os.system(cmd)
 
-    elif provider_src == "local" or provider_dst in clouds:
+    elif provider_src == "local" and provider_dst in clouds:
         typer.secho(f"Copying from local to {provider_dst}", fg="yellow")
         cmd = (
             cloud_provider_api[provider_dst] + " " + path_src + f" s3://{bucket_dst}/{path_dst}" + " --recursive"

--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -219,14 +219,14 @@ def cp(
         )
         confirm_transfer(topo=topo, job=job, ask_to_confirm_transfer=not confirm)
 
-        # If size of transfer smaller than `use_overlay_limit_gb`, default to native cloud solution
+        # If size of transfer smaller than `use_skyplane_limit_gb`, default to native cloud solution
         if (
-            (job.transfer_size / GB) < cloud_config.get_flag("use_overlay_limit_gb")
+            (job.transfer_size / GB) < cloud_config.get_flag("use_skyplane_limit_gb")
             and provider_src == provider_dst
-            and provider_src == "azure"
+            and provider_src != "azure"
         ):
             typer.secho(
-                f"Transfer size ({job.transfer_size / GB} GB) is smaller than the configured limit of {cloud_config.get_flag('use_overlay_limit_gb')} GB",
+                f"Transfer size ({job.transfer_size / GB} GB) is smaller than the configured limit of {cloud_config.get_flag('use_skyplane_limit_gb')} GB",
                 fg="yellow",
             )
             cmd = (

--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -155,7 +155,7 @@ def generate_full_transferobjlist(
     dest_prefix: str,
     recursive: bool = False,
 ) -> List[Tuple[ObjectStoreObject, ObjectStoreObject]]:
-    """Query source region and destination region buckets and return list of objects to transfer."""
+    """Query source region and return list of objects to transfer."""
     source_iface = ObjectStoreInterface.create(source_region, source_bucket)
     dest_iface = ObjectStoreInterface.create(dest_region, dest_bucket)
 

--- a/skyplane/config.py
+++ b/skyplane/config.py
@@ -31,6 +31,7 @@ _FLAG_TYPES = {
     "usage_stats": bool,
     "gcp_service_account_name": str,
     "requester_pays": bool,
+    "use_overlay_limit_gb": int,
 }
 
 _DEFAULT_FLAGS = {
@@ -58,6 +59,7 @@ _DEFAULT_FLAGS = {
     "usage_stats": True,
     "gcp_service_account_name": "skyplane-manual",
     "requester_pays": False,
+    "use_overlay_limit_gb": 2,
 }
 
 

--- a/skyplane/config.py
+++ b/skyplane/config.py
@@ -59,7 +59,7 @@ _DEFAULT_FLAGS = {
     "usage_stats": True,
     "gcp_service_account_name": "skyplane-manual",
     "requester_pays": False,
-    "use_overlay_limit_gb": 2,
+    "use_skyplane_limit_gb": 2,
 }
 
 


### PR DESCRIPTION
Launching overlay VMs adds additional latency and costs for small transfers. For buckets that are smaller than a default limit (2GB) as specified in the configuration, Skyplane will default to the native cloud offering.