### PR TITLE
Increase python version for integration test to 3.10

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -35,20 +35,13 @@ jobs:
       STRATEGY_UUID: itest-${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}
     steps:
       - uses: actions/checkout@v1
+      - name: Install poetry
+        run: pipx install poetry
       - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
           python-version: "3.10"
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.1
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: integration-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py310
-          restore-keys: |
-            integration-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py310
+          cache: "poetry"
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false
@@ -83,20 +76,13 @@ jobs:
       STRATEGY_UUID: itest-d-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v1
+      - name: Install poetry
+        run: pipx install poetry
       - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
           python-version: "3.10"
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.1
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: integration-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py310
-          restore-keys: |
-            integration-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py310
+          cache: "poetry"
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -30,15 +30,15 @@ jobs:
           - azure:westus aws:us-west-1
           - gcp:us-west2-a azure:westus
           - azure:westus gcp:us-west2-a
-    timeout-minutes: 20
+    timeout-minutes: 40
     env:
       STRATEGY_UUID: itest-${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: Install Poetry
         run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.1
       - name: Cache Poetry virtualenv
@@ -46,15 +46,15 @@ jobs:
         id: cache
         with:
           path: ~/.virtualenvs
-          key: poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}
+          key: integration-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py310
           restore-keys: |
-            poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}
+            integration-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py310
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false
           poetry config virtualenvs.path ~/.virtualenvs
       - name: Install Dependencies
-        run: poetry install -E gateway -E solver -E aws -E azure -E gcp
+        run: poetry install -E aws -E azure -E gcp
         if: steps.cache.outputs.cache-hit != 'true'
       - id: 'auth'
         uses: 'google-github-actions/auth@v0'
@@ -83,10 +83,10 @@ jobs:
       STRATEGY_UUID: itest-d-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: Install Poetry
         run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.1
       - name: Cache Poetry virtualenv
@@ -94,9 +94,9 @@ jobs:
         id: cache
         with:
           path: ~/.virtualenvs
-          key: poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}
+          key: integration-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py310
           restore-keys: |
-            poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}
+            integration-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py310
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,20 +30,13 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.1
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: poetry-unit-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py${{ matrix.python-version }}
-          restore-keys: |
-            poetry-unit-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py${{ matrix.python-version }}
+          python-version: "3.10"
+          cache: "poetry"
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,9 +48,9 @@ jobs:
         id: cache
         with:
           path: ~/.virtualenvs
-          key: poetry-unit-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-${{ matrix.python-version }}
+          key: poetry-unit-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py${{ matrix.python-version }}
           restore-keys: |
-            poetry-unit-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-${{ matrix.python-version }}
+            poetry-unit-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-py${{ matrix.python-version }}
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,20 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Install poetry
+        run: pipx install poetry
       - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
           python-version: "3.10"
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.1
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: poetry-lint-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-3.10
-          restore-keys: |
-            poetry-lint-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-3.10
+          cache: "poetry"
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false
@@ -67,20 +60,13 @@ jobs:
     needs: test-unit
     steps:
       - uses: actions/checkout@v1
+      - name: Install poetry
+        run: pipx install poetry
       - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
           python-version: "3.10"
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.1
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: aws-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-3.10
-          restore-keys: |
-            aws-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-3.10
+          cache: "poetry"
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false
@@ -101,22 +87,13 @@ jobs:
     needs: test-unit
     steps:
       - uses: actions/checkout@v1
+      - name: Install poetry
+        run: pipx install poetry
       - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
           python-version: "3.10"
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.1
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: |
-            ~/.virtualenvs
-            /var/cache/apt/archives
-          key: azure-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-3.10
-          restore-keys: |
-            azure-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-3.10
+          cache: "poetry"
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false
@@ -140,20 +117,13 @@ jobs:
       STRATEGY_UUID: pytest-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v1
+      - name: Install poetry
+        run: pipx install poetry
       - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
           python-version: "3.10"
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.1
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: gcp-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-3.10
-          restore-keys: |
-            gcp-poetry-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('pyproject.toml') }}-3.10
+          cache: "poetry"
       - name: Set Poetry config
         run: |
           poetry config virtualenvs.in-project false


### PR DESCRIPTION
This PR reduces the packages installed to avoid the gateway and solver dependencies. This PR also increments the version tested for the integration test to 3.10.