### PR TITLE
Mitigate Azure object store stragglers by limiting gateway connections

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -10,7 +10,7 @@ Skyplane comes with a variety of knobs to tune to adjust performance or change h
 * Transfer parallelism
     * `max_instances`: Maximum number of instances to use for parallel transfers. (default 10)
 * Network configuration
-    * `bbr`: If set, the VM will use BBR congestion control instead of CUBIC. (default False)
+    * `bbr`: If set, the VM will use BBR congestion control instead of CUBIC. (default True)
     * `compress`: If set, gateway VMs will compress data before egress to reduce costs. (default True)
     * `encrypt_e2e`: If set, gateway VMs will encrypt data end-to-end. (default True)
     * `encrypt_socket_tls`: If set, all sockets between gateways will be encrypted with TLS. (default False)

--- a/skyplane/cli/cli_impl/cp_replicate.py
+++ b/skyplane/cli/cli_impl/cp_replicate.py
@@ -334,9 +334,7 @@ def launch_replication_job(
             log_to_file=True,
             time_limit_seconds=time_limit_seconds,
             multipart=multipart_enabled,
-            write_profile=debug,
-            write_socket_profile=debug,
-            copy_gateway_logs=debug,
+            debug=debug,
         )
     except Exception as e:
         if isinstance(e, KeyboardInterrupt):

--- a/skyplane/gateway/gateway_daemon.py
+++ b/skyplane/gateway/gateway_daemon.py
@@ -65,7 +65,7 @@ class GatewayDaemon:
             use_compression=use_compression,
             e2ee_key_bytes=e2ee_key_bytes,
         )
-        self.obj_store_conn = GatewayObjStoreConn(self.chunk_store, self.error_event, self.error_queue, max_conn=32)
+        self.obj_store_conn = GatewayObjStoreConn(self.chunk_store, self.error_event, self.error_queue, max_conn=30)
 
         # Download thread pool
         self.dl_pool_semaphore = BoundedSemaphore(value=128)

--- a/skyplane/gateway/gateway_daemon.py
+++ b/skyplane/gateway/gateway_daemon.py
@@ -65,7 +65,12 @@ class GatewayDaemon:
             use_compression=use_compression,
             e2ee_key_bytes=e2ee_key_bytes,
         )
-        self.obj_store_conn = GatewayObjStoreConn(self.chunk_store, self.error_event, self.error_queue, max_conn=30)
+        provider = region.split(":")[0]
+        if provider == "aws" or provider == "gcp":
+            n_conn = 32
+        elif provider == "azure":
+            n_conn = 24  # due to throttling limits from authentication
+        self.obj_store_conn = GatewayObjStoreConn(self.chunk_store, self.error_event, self.error_queue, max_conn=n_conn)
 
         # Download thread pool
         self.dl_pool_semaphore = BoundedSemaphore(value=128)

--- a/skyplane/replicate/replicator_client.py
+++ b/skyplane/replicate/replicator_client.py
@@ -544,11 +544,7 @@ class ReplicatorClient:
         log_interval_s: Optional[float] = None,
         log_to_file: bool = True,
         time_limit_seconds: Optional[float] = None,
-        cleanup_gateway: bool = True,
-        save_log: bool = True,
-        write_profile: bool = False,
-        write_socket_profile: bool = False,  # slow but useful for debugging
-        copy_gateway_logs: bool = False,
+        debug: bool = False,
         multipart: bool = False,  # multipart object uploads/downloads
     ) -> TransferStats:
         assert job.chunk_requests is not None
@@ -560,8 +556,7 @@ class ReplicatorClient:
         sinks = self.topology.sink_instances()
         sink_regions = set(s.region for s in sinks)
 
-        if save_log:
-            (self.transfer_dir / "job.pkl").write_bytes(pickle.dumps(job))
+        (self.transfer_dir / "job.pkl").write_bytes(pickle.dumps(job))
         try:
             with Progress(
                 SpinnerColumn(),
@@ -609,11 +604,13 @@ class ReplicatorClient:
                         # update progress bar
                         total_runtime_s = (log_df.time.max() - log_df.time.min()).total_seconds()
                         throughput_gbits = completed_bytes * 8 / GB / total_runtime_s if total_runtime_s > 0 else 0.0
-                        pending_chunk_ids = set([cr.chunk.chunk_id for cr in job.chunk_requests]) - set(completed_chunk_ids)
-                        if len(pending_chunk_ids) < 5:
-                            pending_chunks = ", chunks [" + ", ".join([str(cid) for cid in pending_chunk_ids]) + "] remain"
-                        else:
-                            pending_chunks = ""
+
+                        # compute list of chunks that are in progress
+                        pending_chunks = ""
+                        if debug:
+                            pending_chunk_ids = set([cr.chunk.chunk_id for cr in job.chunk_requests]) - set(completed_chunk_ids)
+                            if len(pending_chunk_ids) < 5:
+                                pending_chunks = ", chunks [" + ", ".join([str(cid) for cid in pending_chunk_ids]) + "] remain"
 
                         # make log line
                         progress.update(
@@ -686,24 +683,12 @@ class ReplicatorClient:
                     logger.fs.info(f"Compression ratio: {compression_ratio}")
                     progress.console.print(f"[bold yellow]Compression saved {(1. - compression_ratio)*100.:.2f}% of egress fees")
 
-                if copy_gateway_logs:
+                if debug:
 
                     def copy_log(instance):
                         instance.run_command("sudo docker logs -t skyplane_gateway 2> /tmp/gateway.stderr > /tmp/gateway.stdout")
                         instance.download_file("/tmp/gateway.stdout", self.transfer_dir / f"gateway_{instance.uuid()}.stdout")
                         instance.download_file("/tmp/gateway.stderr", self.transfer_dir / f"gateway_{instance.uuid()}.stderr")
-
-                    progress.update(cleanup_task, description=": Copying gateway logs")
-                    do_parallel(copy_log, self.bound_nodes.values(), n=-1)
-                if write_profile:
-                    progress.update(cleanup_task, description=": Writing chunk profiles")
-                    chunk_status_df = self.get_chunk_status_log_df()
-                    (self.transfer_dir / "chunk_status_df.csv").write_text(chunk_status_df.to_csv(index=False))
-                    traceevent = status_df_to_traceevent(chunk_status_df)
-                    profile_out = self.transfer_dir / f"traceevent_{uuid.uuid4()}.json"
-                    profile_out.parent.mkdir(parents=True, exist_ok=True)
-                    profile_out.write_text(json.dumps(traceevent))
-                if write_socket_profile:
 
                     def write_socket_profile(instance):
                         receiver_reply = self.http_pool.request("GET", f"{instance.gateway_api_url}/api/v1/profile/socket/receiver")
@@ -714,18 +699,32 @@ class ReplicatorClient:
                             )
                         (self.transfer_dir / f"receiver_socket_profile_{instance.uuid()}.json").write_text(text)
 
+                    # copy logs from gateways
+                    progress.update(cleanup_task, description=": Copying gateway logs")
+                    do_parallel(copy_log, self.bound_nodes.values(), n=-1)
+
+                    # write chunk profiles
+                    progress.update(cleanup_task, description=": Writing chunk profiles")
+                    chunk_status_df = self.get_chunk_status_log_df()
+                    (self.transfer_dir / "chunk_status_df.csv").write_text(chunk_status_df.to_csv(index=False))
+                    traceevent = status_df_to_traceevent(chunk_status_df)
+                    profile_out = self.transfer_dir / f"traceevent_{uuid.uuid4()}.json"
+                    profile_out.parent.mkdir(parents=True, exist_ok=True)
+                    profile_out.write_text(json.dumps(traceevent))
+
+                    # write socket profiles
                     progress.update(cleanup_task, description=": Writing socket profiles")
                     do_parallel(write_socket_profile, self.bound_nodes.values(), n=-1)
-                if cleanup_gateway:
 
-                    def fn(s: Server):
-                        try:
-                            self.http_pool.request("POST", f"{s.gateway_api_url}/api/v1/shutdown")
-                        except:
-                            return  # ignore connection errors since server may be shutting down
+                # cleanup gateways
+                def fn(s: Server):
+                    try:
+                        self.http_pool.request("POST", f"{s.gateway_api_url}/api/v1/shutdown")
+                    except:
+                        return  # ignore connection errors since server may be shutting down
 
-                    do_parallel(fn, self.bound_nodes.values(), n=-1)
-                    progress.update(cleanup_task, description=": Shutting down gateways")
+                do_parallel(fn, self.bound_nodes.values(), n=-1)
+                progress.update(cleanup_task, description=": Shutting down gateways")
         raise exceptions.SkyplaneException("Transfer failed, cleanup did not run")  # should never get here
 
     @staticmethod

--- a/skyplane/replicate/replicator_client.py
+++ b/skyplane/replicate/replicator_client.py
@@ -611,7 +611,7 @@ class ReplicatorClient:
                         throughput_gbits = completed_bytes * 8 / GB / total_runtime_s if total_runtime_s > 0 else 0.0
                         pending_chunk_ids = set([cr.chunk.chunk_id for cr in job.chunk_requests]) - set(completed_chunk_ids)
                         if len(pending_chunk_ids) < 5:
-                            pending_chunks = " [" + ", ".join([str(cid) for cid in pending_chunk_ids]) + "]"
+                            pending_chunks = ", chunks [" + ", ".join([str(cid) for cid in pending_chunk_ids]) + "] remain"
                         else:
                             pending_chunks = ""
 

--- a/skyplane/replicate/replicator_client.py
+++ b/skyplane/replicate/replicator_client.py
@@ -609,11 +609,16 @@ class ReplicatorClient:
                         # update progress bar
                         total_runtime_s = (log_df.time.max() - log_df.time.min()).total_seconds()
                         throughput_gbits = completed_bytes * 8 / GB / total_runtime_s if total_runtime_s > 0 else 0.0
+                        pending_chunk_ids = set([cr.chunk.chunk_id for cr in job.chunk_requests]) - set(completed_chunk_ids)
+                        if len(pending_chunk_ids) < 5:
+                            pending_chunks = " [" + ", ".join([str(cid) for cid in pending_chunk_ids]) + "]"
+                        else:
+                            pending_chunks = ""
 
                         # make log line
                         progress.update(
                             copy_task,
-                            description=f" ({len(completed_chunk_ids)} of {len(job.chunk_requests)} chunks)",
+                            description=f" ({len(completed_chunk_ids)} of {len(job.chunk_requests)} chunks{pending_chunks})",
                             completed=completed_bytes,
                         )
                         if len(completed_chunk_ids) == len(job.chunk_requests):


### PR DESCRIPTION
Past 24 connections, Azure blob or Azure auth begins to throttle performance. This PR sets a default limit of 24 connections for Azure.