### PR TITLE
Add flag before deprovisioning networks

### DIFF
--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -16,6 +16,10 @@ import skyplane.cli.usage.definitions
 import skyplane.cli.usage.client
 from skyplane import GB
 from skyplane.cli.usage.client import UsageClient, UsageStatsStatus
+from skyplane.compute.azure.azure_auth import AzureAuthentication
+from skyplane.compute.azure.azure_cloud_provider import AzureCloudProvider
+from skyplane.compute.gcp.gcp_auth import GCPAuthentication
+from skyplane.compute.gcp.gcp_cloud_provider import GCPCloudProvider
 from skyplane.replicate.replicator_client import ReplicatorClient, TransferStats
 
 import typer
@@ -469,7 +473,9 @@ def sync(
 
 
 @app.command()
-def deprovision():
+def deprovision(
+    all: bool = typer.Option(False, "--all", "-a", help="Deprovision all resources including networks."),
+):
     """Deprovision all resources created by skyplane."""
     instances = query_instances()
 
@@ -479,10 +485,16 @@ def deprovision():
     else:
         typer.secho("No instances to deprovision", fg="yellow", bold=True)
 
-    if AWSAuthentication().enabled():
-        aws = AWSCloudProvider()
-        aws.teardown_global()
-
+    if all:
+        if AWSAuthentication().enabled():
+            aws = AWSCloudProvider()
+            aws.teardown_global()
+        if GCPAuthentication().enabled():
+            gcp = GCPCloudProvider()
+            gcp.teardown_global()
+        if AzureAuthentication().enabled():
+            azure = AzureCloudProvider()
+            azure.teardown_global()
 
 @app.command()
 def ssh():

--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -496,6 +496,7 @@ def deprovision(
             azure = AzureCloudProvider()
             azure.teardown_global()
 
+
 @app.command()
 def ssh():
     """SSH into a running gateway."""

--- a/skyplane/compute/cloud_providers.py
+++ b/skyplane/compute/cloud_providers.py
@@ -82,10 +82,10 @@ class CloudProvider:
         raise NotImplementedError
 
     def setup_global(self, **kwargs):
-        raise NotImplementedError
+        pass
 
     def setup_region(self, region: str):
-        raise NotImplementedError
+        pass
 
     def teardown_global(self):
-        raise NotImplementedError
+        pass

--- a/skyplane/compute/gcp/gcp_auth.py
+++ b/skyplane/compute/gcp/gcp_auth.py
@@ -85,9 +85,10 @@ class GCPAuthentication:
             logger.warning(f"Failed to load GCP credentials for project {project_id}: {e}")
             inferred_cred, inferred_project = (None, None)
         if project_id is not None and project_id != inferred_project:
-            logger.warning(
-                f"Google project ID error: Project ID from config {project_id} does not match inferred project from google.auth ADC {inferred_project}. Defaulting to config project."
-            )
+            if inferred_project is not None:
+                logger.warning(
+                    f"Google project ID error: Project ID from config {project_id} does not match inferred project from google.auth ADC {inferred_project}. Defaulting to config project."
+                )
             inferred_project = project_id
         return inferred_cred, inferred_project
 


### PR DESCRIPTION
This has users call `skyplane deprovision --all` in order to clean up cloud networks.