### PR TITLE
Clean up leaked resources upon VM provisioning errors for AWS, GCP and Azure

### DIFF
--- a/skyplane/compute/aws/aws_cloud_provider.py
+++ b/skyplane/compute/aws/aws_cloud_provider.py
@@ -220,7 +220,10 @@ class AWSCloudProvider(CloudProvider):
                     backoff = min(backoff * 2, max_backoff)
 
             assert len(instance) == 1, f"Expected 1 instance, got {len(instance)}"
-            instance[0].wait_until_running()
-            server = AWSServer(f"aws:{region}", instance[0].id)
-            server.wait_for_ssh_ready()
-            return server
+            try:
+                instance[0].wait_until_running()
+            except KeyboardInterrupt:
+                logger.fs.warning(f"Terminating instance {instance[0].id} due to keyboard interrupt")
+                instance[0].terminate()
+                raise
+            return AWSServer(f"aws:{region}", instance[0].id)

--- a/skyplane/compute/azure/azure_cloud_provider.py
+++ b/skyplane/compute/azure/azure_cloud_provider.py
@@ -386,7 +386,13 @@ class AzureCloudProvider(CloudProvider):
                             "priority": "Spot" if use_spot_instances else "Regular",
                         },
                     )
-                    vm_result = poller.result()
+                    try:
+                        vm_result = poller.result()
+                    except KeyboardInterrupt:
+                        logger.fs.warning(f"Terminating instance {name} due to keyboard interrupt")
+                        vm_poller = compute_client.virtual_machines.begin_delete(AzureServer.resource_group_name, AzureServer.vm_name(name))
+                        vm_poller.result()
+                        raise
                     logger.fs.debug(f"Created Azure VM {vm_result.name} w/ system MSI principal_id = {vm_result.identity.principal_id}")
                 except HttpResponseError as e:
                     if "ResourceQuotaExceeded" in str(e):
@@ -395,7 +401,4 @@ class AzureCloudProvider(CloudProvider):
                         raise exceptions.InsufficientVCPUException(f"Got QuotaExceeded error in Azure region {location}") from e
                     else:
                         raise
-
-        server = AzureServer(name)
-        server.wait_for_ssh_ready()
-        return server
+        return AzureServer(name)

--- a/skyplane/compute/gcp/gcp_cloud_provider.py
+++ b/skyplane/compute/gcp/gcp_cloud_provider.py
@@ -381,10 +381,9 @@ class GCPCloudProvider(CloudProvider):
                     raise exceptions.InsufficientVCPUException(f"Got QUOTA_EXCEEDED in region {region}") from e
                 elif "QUOTA_LIMIT" in e.content:
                     raise exceptions.InsufficientVCPUException(f"Got QUOTA_LIMIT in region {region}") from e
-                else:
-                    raise e
-        except KeyboardInterrupt:
+            raise e
+        except KeyboardInterrupt as e:
             logger.fs.info(f"Keyboard interrupt, deleting instance {name}")
             op = compute.instances().delete(project=self.auth.project_id, zone=region, instance=name).execute()
             self.wait_for_operation_to_complete(region, op["name"])
-            raise
+            raise e

--- a/skyplane/replicate/replicator_client.py
+++ b/skyplane/replicate/replicator_client.py
@@ -209,8 +209,9 @@ class ReplicatorClient:
                 )
             else:
                 raise NotImplementedError(f"Unknown provider {provider}")
-            server.enable_auto_shutdown()
             self.temp_nodes.append(server)
+            server.wait_for_ssh_ready()
+            server.enable_auto_shutdown()
             return server
 
         results = do_parallel(


### PR DESCRIPTION
If a transfer exits during VM provisioning, a VM could potentially be leaked. This PR directly cleans up the leaked VM directly in provisioning logic.