### PR TITLE
Sky camp modifications to support CLI guardrails

### DIFF
--- a/skyplane/cli/cli.py
+++ b/skyplane/cli/cli.py
@@ -117,6 +117,10 @@ def cp(
     """
     print_header()
 
+    # check sky camp!
+    assert not reuse_gateways, "Reusing gateways is not supported for Sky Camp!"
+    assert not solve, "Solver is not supported for Sky Camp!"
+
     provider_src, bucket_src, path_src = parse_path(src)
     provider_dst, bucket_dst, path_dst = parse_path(dst)
     src_region_tag, dst_region_tag = f"{provider_src}:infer", f"{provider_dst}:infer"
@@ -324,6 +328,10 @@ def sync(
 
     print_header()
 
+    # check sky camp!
+    assert not reuse_gateways, "Reusing gateways is not supported for Sky Camp!"
+    assert not solve, "Solver is not supported for Sky Camp!"
+
     provider_src, bucket_src, path_src = parse_path(src)
     provider_dst, bucket_dst, path_dst = parse_path(dst)
     src_region_tag, dst_region_tag = f"{provider_src}:infer", f"{provider_dst}:infer"
@@ -473,9 +481,14 @@ def sync(
 @app.command()
 def deprovision(
     all: bool = typer.Option(False, "--all", "-a", help="Deprovision all resources including networks."),
-    filter_client_id: Optional[str] = typer.Option(None, help="Only deprovision instances with this client ID under the instance tag."),
+    filter_client_id: Optional[str] = typer.Option(
+        cloud_config.anon_clientid, help="Only deprovision instances with this client ID under the instance tag."
+    ),
 ):
     """Deprovision all resources created by skyplane."""
+    # sky camp config
+    assert filter_client_id == cloud_config.anon_clientid, "Only deprovisioning instances with your client ID is supported for now."
+
     instances = query_instances()
     if filter_client_id:
         instances = [instance for instance in instances if instance.tags().get("skyplaneclientid") == filter_client_id]

--- a/skyplane/replicate/replicator_client.py
+++ b/skyplane/replicate/replicator_client.py
@@ -262,8 +262,12 @@ class ReplicatorClient:
         public_ips = [self.bound_nodes[n].public_ip() for n in self.topology.gateway_nodes]
         private_ips = [self.bound_nodes[n].private_ip() for n in self.topology.gateway_nodes if n.region.split(":")[0] == "gcp"]
         authorize_ip_jobs = []
+        # sky camp: authorize all IPs
+        # authorize_ip_jobs.extend(
+        #     [partial(self.aws.add_ips_to_security_group, r.split(":")[1], public_ips) for r in set(aws_regions_to_provision)]
+        # )
         authorize_ip_jobs.extend(
-            [partial(self.aws.add_ips_to_security_group, r.split(":")[1], public_ips) for r in set(aws_regions_to_provision)]
+            [partial(self.gcp.add_ips_to_firewall, r.split(":")[1], ["0.0.0.0/0"]) for r in set(gcp_regions_to_provision)]
         )
         if gcp_regions_to_provision:
             authorize_ip_jobs.append(partial(self.gcp.add_ips_to_firewall, public_ips + private_ips))
@@ -321,7 +325,9 @@ class ReplicatorClient:
         private_ips = [i.private_ip() for n, i in self.bound_nodes.items() if n.region.split(":")[0] == "gcp"]
         private_ips += [i.private_ip() for i in self.temp_nodes if i.region_tag.split(":")[0] == "gcp"]
         aws_regions = [node.region for node in self.topology.gateway_nodes if node.region.startswith("aws:")]
-        aws_jobs = [partial(self.aws.remove_ips_from_security_group, r.split(":")[1], public_ips) for r in set(aws_regions)]
+        # sky camp: enable all IPs
+        # aws_jobs = [partial(self.aws.remove_ips_from_security_group, r.split(":")[1], public_ips) for r in set(aws_regions)]
+        aws_jobs = []
         gcp_regions = [node.region for node in self.topology.gateway_nodes if node.region.startswith("gcp:")]
         gcp_jobs = [partial(self.gcp.remove_ips_from_firewall, public_ips + private_ips)] if gcp_regions else []
         do_parallel(lambda fn: fn(), aws_jobs + gcp_jobs, desc="Removing firewall rules")


### PR DESCRIPTION
* Skyplane VPC should allow connections to all ports and IPs
* Disable reuse_gateways for transfers
* Configure deprovision to scope it to a user’s UUID
* Disable GCP and Azure support in Skyplane init