### PR TITLE
Run jobs on pull_request_target to support Github Actions for external contributors

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ '*.*.*' ]
-  pull_request_target:
+  pull_request:
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: s6m1p0n8/skyplane
@@ -29,7 +30,7 @@ jobs:
       # # Install the cosign tool except on PR
       # # https://github.com/sigstore/cosign-installer
       # - name: Install cosign
-      #   # if: github.event_name != 'pull_request_target'
+      #   # if: github.event_name != 'pull_request'
       #   uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
       #   with:
       #     cosign-release: 'v1.4.0'
@@ -77,7 +78,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request_target' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -99,7 +100,7 @@ jobs:
       # # transparency data even for private images, pass --force to cosign below.
       # # https://github.com/sigstore/cosign
       # - name: Sign the published Docker image
-      #   # if: ${{ github.event_name != 'pull_request_target' }}
+      #   # if: ${{ github.event_name != 'pull_request' }}
       #   env:
       #     COSIGN_EXPERIMENTAL: "true"
       #   # This step uses the identity token to provision an ephemeral certificate

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,12 +7,10 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ '*.*.*' ]
-  pull_request:
-    branches: [ main ]
+  pull_request_target:
 
 env:
   IMAGE_NAME: s6m1p0n8/skyplane
-  # IMAGE_NAME: s6m1p0n8/skyplane-test
 
 jobs:
   build:
@@ -31,7 +29,7 @@ jobs:
       # # Install the cosign tool except on PR
       # # https://github.com/sigstore/cosign-installer
       # - name: Install cosign
-      #   # if: github.event_name != 'pull_request'
+      #   # if: github.event_name != 'pull_request_target'
       #   uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
       #   with:
       #     cosign-release: 'v1.4.0'
@@ -79,7 +77,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request_target' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -101,7 +99,7 @@ jobs:
       # # transparency data even for private images, pass --force to cosign below.
       # # https://github.com/sigstore/cosign
       # - name: Sign the published Docker image
-      #   # if: ${{ github.event_name != 'pull_request' }}
+      #   # if: ${{ github.event_name != 'pull_request_target' }}
       #   env:
       #     COSIGN_EXPERIMENTAL: "true"
       #   # This step uses the identity token to provision an ephemeral certificate

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,10 @@
 name: pytest
-on: [push]
+on:
+  push:
+    branches: [ main ]
+    # Publish semver tags as releases.
+    tags: [ '*.*.*' ]
+  pull_request_target:
 jobs:
   black-pytype:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,9 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ '*.*.*' ]
-  pull_request_target:
+  pull_request:
+  workflow_dispatch:
+  
 jobs:
   black-pytype:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github Actions do not execute correctly for pull requests from external contributors (see #630). This PR changes the Github Action target from pull_request to pull_request_target which should now trigger for approved contributors.

@samkumar The risk is that we want to avoid leaking secrets via Github Actions so will only want to run them on approved changes. The pull_request tag by default will not use secrets to run these actions; instead, the pull_request_target trigger was added to run it against secrets. I'm concerned about leaking these secrets still so I want to run a security review with you.

Background reading:
* https://securitylab.github.com/research/github-actions-preventing-pwn-requests
* https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks