### PR TITLE
Migrate chunk IDs from ints to UUIDs

### DIFF
--- a/skyplane/api/impl/tracker.py
+++ b/skyplane/api/impl/tracker.py
@@ -33,8 +33,8 @@ class TransferProgressTracker(Thread):
 
         # transfer state
         self.job_chunk_requests: Dict[str, List[ChunkRequest]] = {}
-        self.job_pending_chunk_ids: Dict[str, Set[int]] = {}
-        self.job_complete_chunk_ids: Dict[str, Set[int]] = {}
+        self.job_pending_chunk_ids: Dict[str, Set[str]] = {}
+        self.job_complete_chunk_ids: Dict[str, Set[str]] = {}
         self.errors: Optional[Dict[str, List[str]]] = None
 
         # http_pool

--- a/skyplane/gateway/chunk_store.py
+++ b/skyplane/gateway/chunk_store.py
@@ -23,25 +23,25 @@ class ChunkStore:
 
         # multiprocess-safe concurrent structures
         self.manager = Manager()
-        self.chunk_requests: Dict[int, ChunkRequest] = self.manager.dict()  # type: ignore
-        self.chunk_status: Dict[int, ChunkState] = self.manager.dict()  # type: ignore
+        self.chunk_requests: Dict[str, ChunkRequest] = self.manager.dict()  # type: ignore
+        self.chunk_status: Dict[str, ChunkState] = self.manager.dict()  # type: ignore
 
         # state log
         self.chunk_status_queue: Queue[Dict] = Queue()
 
         # metric log
-        self.sender_compressed_sizes: Dict[int, float] = self.manager.dict()  # type: ignore
+        self.sender_compressed_sizes: Dict[str, float] = self.manager.dict()  # type: ignore
 
-    def get_chunk_file_path(self, chunk_id: int) -> Path:
-        return self.chunk_dir / f"{chunk_id:05d}.chunk"
+    def get_chunk_file_path(self, chunk_id: str) -> Path:
+        return self.chunk_dir / f"{chunk_id}.chunk"
 
     ###
     # ChunkState management
     ###
-    def get_chunk_state(self, chunk_id: int) -> Optional[ChunkState]:
+    def get_chunk_state(self, chunk_id: str) -> Optional[ChunkState]:
         return self.chunk_status[chunk_id] if chunk_id in self.chunk_status else None
 
-    def set_chunk_state(self, chunk_id: int, new_status: ChunkState, log_metadata: Optional[Dict] = None):
+    def set_chunk_state(self, chunk_id: str, new_status: ChunkState, log_metadata: Optional[Dict] = None):
         self.chunk_status[chunk_id] = new_status
         rec = {"chunk_id": chunk_id, "state": new_status.name, "time": str(datetime.utcnow().isoformat())}
         if log_metadata is not None:
@@ -58,42 +58,42 @@ class ChunkStore:
                 break
         return out_events
 
-    def state_queue_download(self, chunk_id: int):
+    def state_queue_download(self, chunk_id: str):
         state = self.get_chunk_state(chunk_id)
         if state in [ChunkState.registered, ChunkState.download_queued]:
             self.set_chunk_state(chunk_id, ChunkState.download_queued)
         else:
             raise ValueError(f"Invalid transition queue_download from {state} (id={chunk_id})")
 
-    def state_start_download(self, chunk_id: int, receiver_id: Optional[str] = None):
+    def state_start_download(self, chunk_id: str, receiver_id: Optional[str] = None):
         state = self.get_chunk_state(chunk_id)
         if state in [ChunkState.download_queued, ChunkState.download_in_progress]:
             self.set_chunk_state(chunk_id, ChunkState.download_in_progress, {"receiver_id": receiver_id})
         else:
             raise ValueError(f"Invalid transition start_download from {state}")
 
-    def state_finish_download(self, chunk_id: int, receiver_id: Optional[str] = None):
+    def state_finish_download(self, chunk_id: str, receiver_id: Optional[str] = None):
         state = self.get_chunk_state(chunk_id)
         if state in [ChunkState.download_in_progress, ChunkState.downloaded]:
             self.set_chunk_state(chunk_id, ChunkState.downloaded, {"receiver_id": receiver_id})
         else:
             raise ValueError(f"Invalid transition finish_download from {state} (id={chunk_id})")
 
-    def state_queue_upload(self, chunk_id: int):
+    def state_queue_upload(self, chunk_id: str):
         state = self.get_chunk_state(chunk_id)
         if state in [ChunkState.downloaded, ChunkState.upload_queued]:
             self.set_chunk_state(chunk_id, ChunkState.upload_queued)
         else:
             raise ValueError(f"Invalid transition upload_queued from {state} (id={chunk_id})")
 
-    def state_start_upload(self, chunk_id: int, sender_id: Optional[str] = None):
+    def state_start_upload(self, chunk_id: str, sender_id: Optional[str] = None):
         state = self.get_chunk_state(chunk_id)
         if state in [ChunkState.upload_queued, ChunkState.upload_in_progress]:
             self.set_chunk_state(chunk_id, ChunkState.upload_in_progress, {"sender_id": sender_id})
         else:
             raise ValueError(f"Invalid transition start_upload from {state} (id={chunk_id})")
 
-    def state_finish_upload(self, chunk_id: int, sender_id: Optional[str] = None, compressed_size_bytes: Optional[int] = None):
+    def state_finish_upload(self, chunk_id: str, sender_id: Optional[str] = None, compressed_size_bytes: Optional[int] = None):
         state = self.get_chunk_state(chunk_id)
         if state in [ChunkState.upload_in_progress, ChunkState.upload_complete]:
             self.set_chunk_state(chunk_id, ChunkState.upload_complete, {"sender_id": sender_id})
@@ -102,7 +102,7 @@ class ChunkStore:
         else:
             raise ValueError(f"Invalid transition finish_upload from {state} (id={chunk_id})")
 
-    def state_fail(self, chunk_id: int):
+    def state_fail(self, chunk_id: str):
         if self.get_chunk_state(chunk_id) != ChunkState.upload_complete:
             self.set_chunk_state(chunk_id, ChunkState.failed)
         else:
@@ -117,7 +117,7 @@ class ChunkStore:
         else:
             return [req for i, req in self.chunk_requests.items() if self.get_chunk_state(i) == status]
 
-    def get_chunk_request(self, chunk_id: int) -> ChunkRequest:
+    def get_chunk_request(self, chunk_id: str) -> ChunkRequest:
         if chunk_id not in self.chunk_requests:
             raise ValueError(f"ChunkRequest {chunk_id} not found")
         return self.chunk_requests[chunk_id]
@@ -126,7 +126,7 @@ class ChunkStore:
         self.set_chunk_state(chunk_request.chunk.chunk_id, state)
         self.chunk_requests[chunk_request.chunk.chunk_id] = chunk_request
 
-    def update_chunk_checksum(self, chunk_id: int, checksum: Optional[bytes]):
+    def update_chunk_checksum(self, chunk_id: str, checksum: Optional[bytes]):
         cr = self.chunk_requests[chunk_id]
         cr.chunk.checksum = checksum
         self.chunk_requests[chunk_id] = cr

--- a/skyplane/gateway/chunk_store.py
+++ b/skyplane/gateway/chunk_store.py
@@ -131,7 +131,7 @@ class ChunkStore:
         cr.chunk.checksum = checksum
         self.chunk_requests[chunk_id] = cr
 
-    def update_chunk_mime_type(self, chunk_id: int, mime_type: Optional[str]):
+    def update_chunk_mime_type(self, chunk_id: str, mime_type: Optional[str]):
         cr = self.chunk_requests[chunk_id]
         cr.chunk.mime_type = mime_type
         self.chunk_requests[chunk_id] = cr

--- a/skyplane/gateway/gateway_daemon_api.py
+++ b/skyplane/gateway/gateway_daemon_api.py
@@ -128,7 +128,7 @@ class GatewayDaemonAPI(threading.Thread):
             state_name = state.name if state is not None else "unknown"
             return {"req": chunk_req.as_dict(), "state": state_name}
 
-        def get_chunk_reqs(state=None) -> Dict[int, Dict]:
+        def get_chunk_reqs(state=None) -> Dict[str, Dict]:
             out = {}
             for chunk_req in self.chunk_store.get_chunk_requests(state):
                 out[chunk_req.chunk.chunk_id] = make_chunk_req_payload(chunk_req)
@@ -163,8 +163,8 @@ class GatewayDaemonAPI(threading.Thread):
             return jsonify({"chunk_requests": {k: v for k, v in get_chunk_reqs().items() if v["state"] != "upload_complete"}})
 
         # lookup chunk request given chunk worker_id
-        @app.route("/api/v1/chunk_requests/<int:chunk_id>", methods=["GET"])
-        def get_chunk_request(chunk_id: int):
+        @app.route("/api/v1/chunk_requests/<chunk_id>", methods=["GET"])
+        def get_chunk_request(chunk_id: str):
             chunk_req = self.chunk_store.get_chunk_request(chunk_id)
             if chunk_req:
                 return jsonify({"chunk_requests": [make_chunk_req_payload(chunk_req)]})
@@ -179,8 +179,8 @@ class GatewayDaemonAPI(threading.Thread):
             return jsonify({"status": "ok", "n_added": n_added})
 
         # update chunk request
-        @app.route("/api/v1/chunk_requests/<int:chunk_id>", methods=["PUT"])
-        def update_chunk_request(chunk_id: int):
+        @app.route("/api/v1/chunk_requests/<chunk_id>", methods=["PUT"])
+        def update_chunk_request(chunk_id: str):
             chunk_req = self.chunk_store.get_chunk_request(chunk_id)
             if chunk_req is None:
                 return jsonify({"error": f"Chunk {chunk_id} not found"}), 404

--- a/skyplane/gateway/gateway_sender.py
+++ b/skyplane/gateway/gateway_sender.py
@@ -56,7 +56,7 @@ class GatewaySender:
             self.ssl_context = None
 
         # shared state
-        self.worker_queue: queue.Queue[int] = Queue()
+        self.worker_queue: queue.Queue[str] = Queue()
         self.exit_flags = [Event() for _ in range(self.n_processes)]
 
         # process-local state
@@ -64,7 +64,7 @@ class GatewaySender:
         self.sender_port: Optional[int] = None
         self.destination_ports: Dict[str, int] = {}  # ip_address -> int
         self.destination_sockets: Dict[str, socket.socket] = {}  # ip_address -> socket
-        self.sent_chunk_ids: Dict[str, List[int]] = {}  # ip_address -> list of chunk_ids
+        self.sent_chunk_ids: Dict[str, List[str]] = {}  # ip_address -> list of chunk_ids
         self.http_pool = urllib3.PoolManager(retries=urllib3.Retry(total=3), cert_reqs="CERT_NONE")
 
     def start_workers(self):
@@ -157,7 +157,7 @@ class GatewaySender:
         return sock
 
     # send chunks to other instances
-    def send_chunks(self, chunk_ids: List[int], dst_host: str):
+    def send_chunks(self, chunk_ids: List[str], dst_host: str):
         """Send list of chunks to gateway server, pipelining small chunks together into a single socket stream."""
         # notify server of upcoming ChunkRequests
         with Timer(f"prepare to pre-register chunks {chunk_ids} to {dst_host}"):

--- a/skyplane/replicate/replicator_client.py
+++ b/skyplane/replicate/replicator_client.py
@@ -366,7 +366,6 @@ class ReplicatorClient:
             n_objs = 0
             chunks = []
             multipart_pairs = []
-            idx = 0
             for (src_object, dest_object) in job.transfer_pairs:
                 progress.update(prepare_task, description=f": Creating list of chunks for transfer ({n_objs}/{len(job.transfer_pairs)})")
                 n_objs += 1
@@ -375,13 +374,12 @@ class ReplicatorClient:
                         Chunk(
                             src_key=src_object.key,
                             dest_key=dest_object.key,
-                            chunk_id=idx,
+                            chunk_id=uuid.uuid4().hex,
                             file_offset_bytes=0,
                             chunk_length_bytes=job.random_chunk_size_mb * MB,
                             mime_type=dest_object.mime_type,
                         )
                     )
-                    idx += 1
                 elif multipart_enabled and src_object.size > multipart_min_threshold_mb * MB:
                     # transfer entire object
                     multipart_pairs.append((src_object, dest_object))
@@ -389,13 +387,12 @@ class ReplicatorClient:
                     chunk = Chunk(
                         src_key=src_object.key,
                         dest_key=dest_object.key,
-                        chunk_id=idx,
+                        chunk_id=uuid.uuid4().hex,
                         file_offset_bytes=0,
                         chunk_length_bytes=src_object.size,
                         mime_type=dest_object.mime_type,
                     )
                     chunks.append(chunk)
-                    idx += 1
 
             # initiate multipart transfers in parallel
             if not job.random_chunk_size_mb:
@@ -438,7 +435,7 @@ class ReplicatorClient:
                             Chunk(
                                 src_key=src_object.key,
                                 dest_key=dest_object.key,
-                                chunk_id=idx,
+                                chunk_id=uuid.uuid4().hex,
                                 file_offset_bytes=offset,
                                 chunk_length_bytes=file_size_bytes,
                                 part_number=part_num,
@@ -448,7 +445,6 @@ class ReplicatorClient:
                         )
                         parts.append(part_num)
 
-                        idx += 1
                         part_num += 1
                         offset += chunk_size_bytes
                     # add multipart upload request


### PR DESCRIPTION
This PR is required in order to support concurrent transfers for the API. This enables the API to concurrently generate chunks from multiple transfers without risk of collision.