### PR TITLE
Update exception chaining logic to remove long traceback

### DIFF
--- a/skyplane/api/impl/transfer_job.py
+++ b/skyplane/api/impl/transfer_job.py
@@ -72,7 +72,7 @@ class TransferJob:
                     dest_key = self._map_object_key_prefix(self.src_prefix, obj.key, self.dst_prefix, recursive=self.recursive)
                 except exceptions.MissingObjectException as e:
                     logger.fs.exception(e)
-                    raise e
+                    raise e from None
 
                 # make destination object
                 dest_provider, dest_region = self.dst_iface.region_tag().split(":")

--- a/skyplane/compute/aws/aws_cloud_provider.py
+++ b/skyplane/compute/aws/aws_cloud_provider.py
@@ -224,7 +224,7 @@ class AWSCloudProvider(CloudProvider):
                     break
                 except exceptions.ClientError as e:
                     if i == max_retries - 1:
-                        raise e
+                        raise
                     elif "VcpuLimitExceeded" in str(e):
                         raise skyplane_exceptions.InsufficientVCPUException() from e
                     elif "Invalid IAM Instance Profile name" not in str(e):

--- a/skyplane/compute/aws/aws_network.py
+++ b/skyplane/compute/aws/aws_network.py
@@ -179,7 +179,7 @@ class AWSNetwork:
             else:
                 logger.error(f"[aws_network]:{aws_region} Error adding IPs {ips} to security group {sg.group_name}")
                 logger.fs.exception(e)
-                raise e
+                raise e from None
 
     @imports.inject("botocore.exceptions", pip_extra="aws")
     def remove_ips_from_security_group(exceptions, self, aws_region: str, ips: List[str]):
@@ -218,4 +218,4 @@ class AWSNetwork:
             else:
                 logger.error(f"[aws_network]:{aws_region} Error adding SSH port {port} for IPs {ip} to security group {sg.group_name}")
                 logger.fs.exception(e)
-                raise e
+                raise e from None

--- a/skyplane/compute/gcp/gcp_cloud_provider.py
+++ b/skyplane/compute/gcp/gcp_cloud_provider.py
@@ -171,7 +171,7 @@ class GCPCloudProvider(CloudProvider):
                 )
                 self.wait_for_operation_to_complete("global", op["name"])
             else:
-                raise e
+                raise
 
     @imports.inject("googleapiclient.errors", pip_extra="gcp")
     def configure_skyplane_firewall(errors, self, ip="0.0.0.0/0"):
@@ -191,7 +191,7 @@ class GCPCloudProvider(CloudProvider):
             if e.resp.status == 404:
                 current_firewall = None
             else:
-                raise e
+                raise
 
         fw_body = {
             "name": "skyplanessh",
@@ -262,7 +262,7 @@ class GCPCloudProvider(CloudProvider):
                 if e.resp.status == 404:
                     current_firewall = None
                 else:
-                    raise e
+                    raise
             if current_firewall is None:
                 create_firewall(fw_body, update_firewall=False)
                 logger.fs.debug(f"[GCP] Created new firewall {firewall_name}")
@@ -282,7 +282,7 @@ class GCPCloudProvider(CloudProvider):
                 if e.resp.status == 404:  # Firewall doesnt exist. Continue
                     logger.fs.warning(f"[GCP] Unable to delete {firewall_name}, does not exist.")
                 else:
-                    raise e
+                    raise
 
     def get_operation_state(self, zone, operation_name):
         compute = self.auth.get_gcp_client()
@@ -393,9 +393,9 @@ class GCPCloudProvider(CloudProvider):
                     raise exceptions.InsufficientVCPUException(f"Got QUOTA_EXCEEDED in region {region}") from e
                 elif "QUOTA_LIMIT" in e.content:
                     raise exceptions.InsufficientVCPUException(f"Got QUOTA_LIMIT in region {region}") from e
-            raise e
+            raise
         except KeyboardInterrupt as e:
             logger.fs.info(f"Keyboard interrupt, deleting instance {name}")
             op = compute.instances().delete(project=self.auth.project_id, zone=region, instance=name).execute()
             self.wait_for_operation_to_complete(region, op["name"])
-            raise e
+            raise

--- a/skyplane/compute/server.py
+++ b/skyplane/compute/server.py
@@ -369,7 +369,7 @@ class Server:
             logs, err = self.run_command(f"sudo docker logs skyplane_gateway --tail=100")
             logger.fs.error(f"Docker logs: {logs}\nerr: {err}")
             logger.fs.exception(e)
-            raise e
+            raise e from None
         finally:
             logging.disable(logging.NOTSET)
 

--- a/skyplane/obj_store/azure_blob_interface.py
+++ b/skyplane/obj_store/azure_blob_interface.py
@@ -92,7 +92,7 @@ class AzureBlobInterface(ObjectStoreInterface):
                 logger.error(
                     f"Unable to list objects in container {self.container_name} as you don't have permission to access it. You need the 'Storage Blob Data Contributor' and 'Storage Account Contributor' roles: {e}"
                 )
-                raise e
+                raise e from None
 
     def delete_objects(self, keys: List[str]):
         for key in keys:

--- a/skyplane/obj_store/gcs_interface.py
+++ b/skyplane/obj_store/gcs_interface.py
@@ -77,7 +77,7 @@ class GCSInterface(ObjectStoreInterface):
         except Exception as e:
             if "The specified bucket does not exist" in str(e):
                 return False
-            raise e
+            raise
 
     def exists(self, obj_name):
         try:

--- a/skyplane/obj_store/s3_interface.py
+++ b/skyplane/obj_store/s3_interface.py
@@ -65,7 +65,7 @@ class S3Interface(ObjectStoreInterface):
         except botocore_exceptions.ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchBucket" or e.response["Error"]["Code"] == "AccessDenied":
                 return False
-            raise e
+            raise
 
     def create_bucket(self, aws_region):
         s3_client = self._s3_client(aws_region)

--- a/skyplane/utils/fn.py
+++ b/skyplane/utils/fn.py
@@ -43,7 +43,7 @@ def do_parallel(
             return args, func(args)
         except Exception as e:
             logger.error(f"Error running {func.__name__}: {e}")
-            raise e
+            raise
 
     results = []
     with Progress(

--- a/skyplane/utils/retry.py
+++ b/skyplane/utils/retry.py
@@ -26,7 +26,7 @@ def retry_backoff(
             return fn()
         except exception_class as e:
             if i == max_retries - 1 or type(e) in always_raise_exceptions:
-                raise e
+                raise
             else:
                 # ignore retries due to IAM instance profile propagation
                 if log_errors:


### PR DESCRIPTION
@phi-line suggested the `raise e from None` syntax. I tested it out, and it substantially improves the readability of tracebacks. However, I would like to still raise exceptions from cloud SDKs unmodified. Therefore, I convert those usages from `raise e` to simply `raise` which raises cloud exceptions without unnecessary chaining (while preserving chaining within the cloud SDKs).