### PR TITLE
fix: mismatched console markup

### DIFF
--- a/skyplane/cli/cli_transfer.py
+++ b/skyplane/cli/cli_transfer.py
@@ -217,7 +217,7 @@ class SkyplaneCLI:
                 console.print("[bold][red]Transfer cancelled by user.[/red][/bold]")
                 raise typer.Abort()
         else:
-            console.print("[green]Transfer starting[/bold]")
+            console.print("[green]Transfer starting[/green]")
             return True
 
     def estimate_small_transfer(self, dp: skyplane.Dataplane, size_threshold_bytes: float, query_n: int = 1000) -> bool:


### PR DESCRIPTION
Fixes an issue where running skyplane with the `-y` option fails with the following error:

```
MarkupError: closing tag '[/bold]' at position 24 doesn't match any open tag
```

This change simply updates the markup tags to match.