### PR TITLE
Add quotes around pip install command for alternative shells like Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,18 @@ Skyplane is an actively developed project. It will have 🔪 SHARP EDGES 🔪. P
 ## 1. Installation
 We recommend installation from PyPi:
 ```
-$ pip install skyplane[aws]
+$ pip install "skyplane[aws]"
 
 # install support for other clouds as needed:
-#   $ pip install skyplane[azure]
-#   $ pip install skyplane[gcp]
-#   $ pip install skyplane[all]
+#   $ pip install "skyplane[azure]"
+#   $ pip install "skyplane[gcp]"
+#   $ pip install "skyplane[all]"
 ```
 
-Skyplane supports AWS, Azure, and GCP. You can install Skyplane with support for one or more of these clouds by specifying the corresponding extras. To install two out of three clouds, you can run `pip install skyplane[aws,azure]`.
+Skyplane supports AWS, Azure, and GCP. You can install Skyplane with support for one or more of these clouds by specifying the corresponding extras. To install two out of three clouds, you can run `pip install "skyplane[aws,azure]"`.
 
 *GCP support on the M1 Mac*: If you are using an M1 Mac with the arm64 architecture and want to install GCP support for Skyplane, you will need to install as follows
-`GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install skyplane[aws,gcp]`
+`GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install "skyplane[aws,gcp]"`
 
 ## 2. Setup Cloud Credentials 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,12 +9,12 @@ We're ready to install Skyplane. It's as easy as:
 .. code-block:: bash
 
    ---> Install skyplane from PyPI:
-   $ pip install skyplane[aws]
+   $ pip install "skyplane[aws]"
 
    # install support for other clouds as needed:
-   #   $ pip install skyplane[azure]
-   #   $ pip install skyplane[gcp]
-   #   $ pip install skyplane[all]
+   #   $ pip install "skyplane[azure]"
+   #   $ pip install "skyplane[gcp]"
+   #   $ pip install "skyplane[all]"
 
 .. dropdown for M1 Macbook users
 .. note::


### PR DESCRIPTION
From Slack (https://skyplaneworkspace.slack.com/archives/C03MX5BEVSM/p1672875577690879), it seems like Zsh requires quotes to install Skyplane with cloud extras.
