### PR TITLE
[Fix] the azure auth issue

### DIFF
--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -15,9 +15,7 @@ from skyplane.utils.fn import do_parallel, wait_for
 
 class AzureAuthentication:
     def __init__(self, config: Optional[SkyplaneConfig] = None):
-        self.config = (
-            config if config is not None else SkyplaneConfig.load_config(config_path)
-        )
+        self.config = config if config is not None else SkyplaneConfig.load_config(config_path)
         self._credential = None
 
     @property
@@ -30,9 +28,7 @@ class AzureAuthentication:
         if self._credential is None:
             if is_gateway_env:
                 print("Configured managed identity credential.")
-                return ManagedIdentityCredential(
-                    client_id=self.config.azure_umi_client_id
-                )
+                return ManagedIdentityCredential(client_id=self.config.azure_umi_client_id)
             else:
                 if query_which_cloud() != "azure":
                     return DefaultAzureCredential(
@@ -60,9 +56,7 @@ class AzureAuthentication:
             self.clear_region_config()
             return
         region_list = []
-        for location in self.get_subscription_client().subscriptions.list_locations(
-            subscription_id=self.subscription_id
-        ):
+        for location in self.get_subscription_client().subscriptions.list_locations(subscription_id=self.subscription_id):
             region_list.append(location.name)
         with azure_config_path.open("w") as f:
             f.write("\n".join(region_list))
@@ -70,9 +64,7 @@ class AzureAuthentication:
 
         def get_skus(region):
             valid_skus = []
-            for sku in client.resource_skus.list(
-                filter="location eq '{}'".format(region)
-            ):
+            for sku in client.resource_skus.list(filter="location eq '{}'".format(region)):
                 if len(sku.restrictions) == 0:
                     valid_skus.append(sku.name)
             return set(valid_skus)
@@ -109,9 +101,7 @@ class AzureAuthentication:
         try:
             f = open(azure_sku_path, "r")
         except FileNotFoundError:
-            print(
-                "     Azure SKU data has not been chaced! Run skyplane init to remedy this!"
-            )
+            print("     Azure SKU data has not been chaced! Run skyplane init to remedy this!")
             return dict()
 
         return json.load(f)
@@ -129,12 +119,7 @@ class AzureAuthentication:
             return os.environ["AZURE_SUBSCRIPTION_ID"]
         else:
             try:
-                return (
-                    subprocess.check_output(["az", "account", "show", "--query", "id"])
-                    .decode("utf-8")
-                    .replace('"', "")
-                    .strip()
-                )
+                return subprocess.check_output(["az", "account", "show", "--query", "id"]).decode("utf-8").replace('"', "").strip()
             except subprocess.CalledProcessError:
                 return None
 
@@ -157,23 +142,17 @@ class AzureAuthentication:
     def get_network_client(NetworkManagementClient, self):
         return NetworkManagementClient(self.credential, self.subscription_id)
 
-    @imports.inject(
-        "azure.mgmt.authorization.AuthorizationManagementClient", pip_extra="azure"
-    )
+    @imports.inject("azure.mgmt.authorization.AuthorizationManagementClient", pip_extra="azure")
     def get_authorization_client(AuthorizationManagementClient, self):
         # set API version to avoid UnsupportedApiVersionForRoleDefinitionHasDataActions error
-        return AuthorizationManagementClient(
-            self.credential, self.subscription_id, api_version="2018-01-01-preview"
-        )
+        return AuthorizationManagementClient(self.credential, self.subscription_id, api_version="2018-01-01-preview")
 
     @imports.inject("azure.mgmt.storage.StorageManagementClient", pip_extra="azure")
     def get_storage_management_client(StorageManagementClient, self):
         return StorageManagementClient(self.credential, self.subscription_id)
 
     @imports.inject("azure.storage.blob.ContainerClient", pip_extra="azure")
-    def get_container_client(
-        ContainerClient, self, account_url: str, container_name: str
-    ):
+    def get_container_client(ContainerClient, self, account_url: str, container_name: str):
         return ContainerClient(account_url, container_name, credential=self.credential)
 
     @imports.inject("azure.storage.blob.BlobServiceClient", pip_extra="azure")

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -15,16 +15,24 @@ from skyplane.utils.fn import do_parallel, wait_for
 
 class AzureAuthentication:
     def __init__(self, config: Optional[SkyplaneConfig] = None):
-        self.config = config if config is not None else SkyplaneConfig.load_config(config_path)
+        self.config = (
+            config if config is not None else SkyplaneConfig.load_config(config_path)
+        )
         self._credential = None
 
     @property
-    @imports.inject("azure.identity.DefaultAzureCredential", "azure.identity.ManagedIdentityCredential", pip_extra="azure")
+    @imports.inject(
+        "azure.identity.DefaultAzureCredential",
+        "azure.identity.ManagedIdentityCredential",
+        pip_extra="azure",
+    )
     def credential(DefaultAzureCredential, ManagedIdentityCredential, self):
         if self._credential is None:
             if is_gateway_env:
                 print("Configured managed identity credential.")
-                return ManagedIdentityCredential(client_id=self.config.azure_umi_client_id)
+                return ManagedIdentityCredential(
+                    client_id=self.config.azure_umi_client_id
+                )
             else:
                 if query_which_cloud() != "azure":
                     return DefaultAzureCredential(
@@ -34,8 +42,11 @@ class AzureAuthentication:
                         exclude_visual_studio_code_credential=True,
                     )
                 else:
+                    print(self.config)
                     return DefaultAzureCredential(
-                        managed_identity_client_id=self.config.azure_client_id,
+                        managed_identity_client_id=self.config.azure_client_id
+                        if isinstance(self.config, SkyplaneConfig)
+                        else self.config.azure_umi_client_id,
                         exclude_powershell_credential=True,
                         exclude_visual_studio_code_credential=True,
                     )
@@ -50,7 +61,9 @@ class AzureAuthentication:
             self.clear_region_config()
             return
         region_list = []
-        for location in self.get_subscription_client().subscriptions.list_locations(subscription_id=self.subscription_id):
+        for location in self.get_subscription_client().subscriptions.list_locations(
+            subscription_id=self.subscription_id
+        ):
             region_list.append(location.name)
         with azure_config_path.open("w") as f:
             f.write("\n".join(region_list))
@@ -58,7 +71,9 @@ class AzureAuthentication:
 
         def get_skus(region):
             valid_skus = []
-            for sku in client.resource_skus.list(filter="location eq '{}'".format(region)):
+            for sku in client.resource_skus.list(
+                filter="location eq '{}'".format(region)
+            ):
                 if len(sku.restrictions) == 0:
                     valid_skus.append(sku.name)
             return set(valid_skus)
@@ -95,7 +110,9 @@ class AzureAuthentication:
         try:
             f = open(azure_sku_path, "r")
         except FileNotFoundError:
-            print("     Azure SKU data has not been chaced! Run skyplane init to remedy this!")
+            print(
+                "     Azure SKU data has not been chaced! Run skyplane init to remedy this!"
+            )
             return dict()
 
         return json.load(f)
@@ -113,7 +130,12 @@ class AzureAuthentication:
             return os.environ["AZURE_SUBSCRIPTION_ID"]
         else:
             try:
-                return subprocess.check_output(["az", "account", "show", "--query", "id"]).decode("utf-8").replace('"', "").strip()
+                return (
+                    subprocess.check_output(["az", "account", "show", "--query", "id"])
+                    .decode("utf-8")
+                    .replace('"', "")
+                    .strip()
+                )
             except subprocess.CalledProcessError:
                 return None
 
@@ -136,17 +158,23 @@ class AzureAuthentication:
     def get_network_client(NetworkManagementClient, self):
         return NetworkManagementClient(self.credential, self.subscription_id)
 
-    @imports.inject("azure.mgmt.authorization.AuthorizationManagementClient", pip_extra="azure")
+    @imports.inject(
+        "azure.mgmt.authorization.AuthorizationManagementClient", pip_extra="azure"
+    )
     def get_authorization_client(AuthorizationManagementClient, self):
         # set API version to avoid UnsupportedApiVersionForRoleDefinitionHasDataActions error
-        return AuthorizationManagementClient(self.credential, self.subscription_id, api_version="2018-01-01-preview")
+        return AuthorizationManagementClient(
+            self.credential, self.subscription_id, api_version="2018-01-01-preview"
+        )
 
     @imports.inject("azure.mgmt.storage.StorageManagementClient", pip_extra="azure")
     def get_storage_management_client(StorageManagementClient, self):
         return StorageManagementClient(self.credential, self.subscription_id)
 
     @imports.inject("azure.storage.blob.ContainerClient", pip_extra="azure")
-    def get_container_client(ContainerClient, self, account_url: str, container_name: str):
+    def get_container_client(
+        ContainerClient, self, account_url: str, container_name: str
+    ):
         return ContainerClient(account_url, container_name, credential=self.credential)
 
     @imports.inject("azure.storage.blob.BlobServiceClient", pip_extra="azure")

--- a/skyplane/compute/azure/azure_auth.py
+++ b/skyplane/compute/azure/azure_auth.py
@@ -42,7 +42,6 @@ class AzureAuthentication:
                         exclude_visual_studio_code_credential=True,
                     )
                 else:
-                    print(self.config)
                     return DefaultAzureCredential(
                         managed_identity_client_id=self.config.azure_client_id
                         if isinstance(self.config, SkyplaneConfig)


### PR DESCRIPTION
Edit instance config for Azure: 
`if isinstance(self.config, SkyplaneConfig) else self.config.azure_umi_client_id`

in in `DefaultAzureCredential()`

Fixes the following issue -
```
00:22:03 [ERROR] Error running <lambda>: 'AzureConfig' object has no attribute 'azure_client_id'
Traceback (most recent call last):
  File "/home/zzz/workspace/skyplane/skyplane/cli/cli_transfer.py", line 366, in cp
    dp.provision(spinner=True)
  File "/home/zzz/workspace/skyplane/skyplane/api/dataplane.py", line 119, in provision
    self.provisioner.init_global(
  File "/home/zzz/workspace/skyplane/skyplane/api/provisioner.py", line 104, in init_global
    do_parallel(lambda fn: fn(), jobs, spinner=False)
  File "/home/zzz/workspace/skyplane/skyplane/utils/fn.py", line 57, in do_parallel
    args, result = future.result()
  File "/home/zzz/.pyenv/versions/3.8.10/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/home/zzz/.pyenv/versions/3.8.10/lib/python3.8/concurrent/futures/_base.py", line 389, in
__get_result
    raise self._exception
  File "/home/zzz/.pyenv/versions/3.8.10/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/zzz/workspace/skyplane/skyplane/utils/fn.py", line 43, in wrapped_fn
    return args, func(args)
  File "/home/zzz/workspace/skyplane/skyplane/api/provisioner.py", line 104, in <lambda>
    do_parallel(lambda fn: fn(), jobs, spinner=False)
  File "/home/zzz/workspace/skyplane/skyplane/compute/azure/azure_cloud_provider.py", line 204, in
set_up_resource_group
    resource_client = self.auth.get_resource_client()
  File "/home/zzz/workspace/skyplane/skyplane/utils/imports.py", line 33, in wrapped
    return fn(*modules_imported, *args, **kwargs)
  File "/home/zzz/workspace/skyplane/skyplane/compute/azure/azure_auth.py", line 129, in
get_resource_client
    return ResourceManagementClient(self.credential, self.subscription_id)
  File "/home/zzz/workspace/skyplane/skyplane/utils/imports.py", line 33, in wrapped
    return fn(*modules_imported, *args, **kwargs)
  File "/home/zzz/workspace/skyplane/skyplane/compute/azure/azure_auth.py", line 38, in credential
    managed_identity_client_id=self.config.azure_client_id,
AttributeError: 'AzureConfig' object has no attribute 'azure_client_id'
```

The reformat is done by `black`