### PR TITLE
[Fix] Client in CLI uses correct transfer config

### DIFF
--- a/skyplane/cli/cli_transfer.py
+++ b/skyplane/cli/cli_transfer.py
@@ -55,7 +55,9 @@ class SkyplaneCLI:
         self.args = args
         self.aws_config, self.azure_config, self.gcp_config = self.to_api_config(skyplane_config or cloud_config)
         self.transfer_config = self.make_transfer_config(skyplane_config or cloud_config)
-        self.client = skyplane.SkyplaneClient(aws_config=self.aws_config, azure_config=self.azure_config, gcp_config=self.gcp_config)
+        self.client = skyplane.SkyplaneClient(
+            aws_config=self.aws_config, azure_config=self.azure_config, gcp_config=self.gcp_config, transfer_config=self.transfer_config
+        )
         typer.secho(f"Using Skyplane version {skyplane.__version__}", fg="bright_black")
         typer.secho(f"Logging to: {self.client.log_dir / 'client.log'}", fg="bright_black")
 


### PR DESCRIPTION
This fixes the issue that the cli uses the default transfer config. 

After ` skyplane config set azure_instance_class DCASv5`, run cp command, found the following logs.
```
 23:40:45 [DEBUG] User confirmed transfer
23:40:45 [INFO]  [Provisioner.add_task] Queue ProvisionerTask(cloud_provider=‘azure’, region=‘eastus’, 
vm_type=‘Standard_D2_v5’, ...)
```

With the fix, the logs became
```
00:42:14 [DEBUG] User confirmed transfer
00:42:14 [INFO]  [Provisioner.add_task] Queue ProvisionerTask(cloud_provider='azure', region='eastus', 
vm_type='DCASv5', ...)
```