### PR TITLE
[Fix] gateway requirements

### DIFF
--- a/scripts/requirements-gateway.txt
+++ b/scripts/requirements-gateway.txt
@@ -22,3 +22,5 @@ flask
 lz4
 pyopenssl
 werkzeug
+numpy
+pandas


### PR DESCRIPTION
Got this issue when testing Skyplane

```
Starting TLS tunnels: /etc/stunnel/stunnel.conf: started (no pid=pidfile specified!)
18:49:04 [WARN]  pandas not installed, will not be able to load transfer costs
Traceback (most recent call last):
  File "/pkg/skyplane/gateway/gateway_daemon.py", line 16, in <module>
    from skyplane.chunk import ChunkState
  File "/pkg/skyplane/__init__.py", line 4, in <module>
    from skyplane.api.client import SkyplaneClient
  File "/pkg/skyplane/api/client.py", line 11, in <module>
    from skyplane.planner.planner import DirectPlanner, ILPSolverPlanner, RONSolverPlanner
  File "/pkg/skyplane/planner/planner.py", line 4, in <module>
    from skyplane.planner.solver import ThroughputProblem
  File "/pkg/skyplane/planner/solver.py", line 6, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
```

The error went away after this fix.