### PR TITLE
[fix] Copy gateway logs on interrupt

### DIFF
--- a/skyplane/api/tracker.py
+++ b/skyplane/api/tracker.py
@@ -12,7 +12,6 @@ from skyplane import exceptions
 from skyplane.api.config import TransferConfig
 from skyplane.chunk import ChunkRequest, ChunkState, Chunk
 from skyplane.utils import logger, imports
-from skyplane.utils.definitions import tmp_log_dir
 from skyplane.utils.fn import do_parallel
 from skyplane.api.usage import UsageClient
 from skyplane.utils.definitions import GB
@@ -92,8 +91,7 @@ class TransferProgressTracker(Thread):
         self.dataplane = dataplane
         self.jobs = {job.uuid: job for job in jobs}
         self.transfer_config = transfer_config
-        self.transfer_dir = tmp_log_dir / "transfer_logs" / datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.transfer_dir.mkdir(exist_ok=True, parents=True)
+
         if hooks is None:
             self.hooks = EmptyTransferHook()
         else:
@@ -225,7 +223,7 @@ class TransferProgressTracker(Thread):
             errors = self.dataplane.check_error_logs()
             if any(errors.values()):
                 logger.warning("Copying gateway logs...")
-                do_parallel(self.copy_log, self.dataplane.bound_nodes.values(), n=-1)
+                do_parallel(self.dataplane.copy_log, self.dataplane.bound_nodes.values(), n=-1)
                 self.errors = errors
                 raise exceptions.SkyplaneGatewayException("Transfer failed with errors", errors)
 
@@ -322,8 +320,3 @@ class TransferProgressTracker(Thread):
                 ]
             )
         return sum(bytes_total_per_job.values())
-
-    def copy_log(self, instance):
-        instance.run_command("sudo docker logs -t skyplane_gateway 2> /tmp/gateway.stderr > /tmp/gateway.stdout")
-        instance.download_file("/tmp/gateway.stdout", self.transfer_dir / f"gateway_{instance.uuid()}.stdout")
-        instance.download_file("/tmp/gateway.stderr", self.transfer_dir / f"gateway_{instance.uuid()}.stderr")

--- a/skyplane/cli/cli_transfer.py
+++ b/skyplane/cli/cli_transfer.py
@@ -354,7 +354,8 @@ def cp(
                 dp.run(ProgressBarTransferHook())
             except KeyboardInterrupt:
                 logger.fs.warning("Transfer cancelled by user (KeyboardInterrupt)")
-                console.print("\n[bold red]Transfer cancelled by user. Exiting.[/bold red]")
+                console.print("\n[bold red]Transfer cancelled by user. Copying gateway logs and exiting.[/bold red]")
+                do_parallel(dp.copy_log, dp.bound_nodes.values(), n=-1)
                 force_deprovision(dp)
             except skyplane.exceptions.SkyplaneException as e:
                 console.print(f"[bright_black]{traceback.format_exc()}[/bright_black]")


### PR DESCRIPTION
On keyboard interrupt for a transfer, gateway logs are not copied so diagnosing status of transfers can be difficult. This is part one of a deprovisioning error fix for keyboard interrupts.