### PR TITLE
Resolve redundant GCP logs in load_gcp_config

### DIFF
--- a/skyplane/api/transfer_job.py
+++ b/skyplane/api/transfer_job.py
@@ -9,7 +9,7 @@ from abc import ABC
 from collections import defaultdict
 from dataclasses import dataclass, field
 from queue import Queue
-from typing import TYPE_CHECKING, Callable, Generator, List, Optional, Tuple, TypeVar
+from typing import TYPE_CHECKING, Callable, Generator, Optional, Tuple, TypeVar
 
 import urllib3
 from rich import print as rprint

--- a/skyplane/cli/cli_init.py
+++ b/skyplane/cli/cli_init.py
@@ -333,7 +333,7 @@ def load_gcp_config(config: SkyplaneConfig, force_init: bool = False, non_intera
             return disable_gcp_support()
         else:
             typer.secho("    GCP credentials found in GCP CLI", fg="blue")
-            if non_interactive or typer.confirm("    GCP credentials found, do you want to enable GCP support in Skyplane?", default=True):
+            if non_interactive or typer.confirm("    Do you want to enable GCP support in Skyplane?", default=True):
                 if not non_interactive:
                     config.gcp_project_id = typer.prompt("    Enter the GCP project ID", default=inferred_project)
 

--- a/skyplane/cli/cli_transfer.py
+++ b/skyplane/cli/cli_transfer.py
@@ -26,7 +26,6 @@ from skyplane.obj_store.file_system_interface import FileSystemInterface
 from skyplane.cli.impl.progress_bar import ProgressBarTransferHook
 from skyplane.utils import logger
 from skyplane.utils.definitions import GB, format_bytes
-from skyplane.utils.fn import do_parallel
 from skyplane.utils.path import parse_path
 
 

--- a/skyplane/compute/aws/aws_auth.py
+++ b/skyplane/compute/aws/aws_auth.py
@@ -1,6 +1,5 @@
 from typing import Optional, Dict
 import json
-import os
 
 from skyplane.config import SkyplaneConfig
 from skyplane.config_paths import config_path, aws_config_path, aws_quota_path

--- a/skyplane/obj_store/hdfs_interface.py
+++ b/skyplane/obj_store/hdfs_interface.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Iterator, List, Optional
 from skyplane.exceptions import NoSuchObjectException
 from skyplane.obj_store.object_store_interface import ObjectStoreInterface, ObjectStoreObject
-from skyplane.utils import imports, logger
+from skyplane.utils import logger
 import mimetypes
 
 

--- a/skyplane/obj_store/posix_file_interface.py
+++ b/skyplane/obj_store/posix_file_interface.py
@@ -88,7 +88,7 @@ class POSIXInterface(ObjectStoreInterface):
         for key in keys:
             try:
                 os.remove(key)
-            except OSError as error:
+            except OSError:
                 print(f"{key} is a directory, not a file. Skipping.", file=sys.stderr)
                 continue
         return True

--- a/skyplane/obj_store/s3_interface.py
+++ b/skyplane/obj_store/s3_interface.py
@@ -1,5 +1,4 @@
 import base64
-import time
 import hashlib
 import os
 from functools import lru_cache


### PR DESCRIPTION
Intended to resolve #627

With my understanding, the redundancy was that "GCP credentials found" was repeated twice. I adjusted the line in cli_init.py::load_gcp_config as a result. Please let me know if there's a redundancy I'm not seeing.

All the other changes were due to running `autoflake --in-place --remove-all-unused-imports --remove-unused-variables --recursive skyplane` as per the contribution guidelines.