### PR TITLE
[Fix] exit before transfer all the files.

### DIFF
--- a/skyplane/api/transfer_job.py
+++ b/skyplane/api/transfer_job.py
@@ -341,7 +341,7 @@ class Chunker:
                     yield multipart_chunk_queue.get()
 
         if self.transfer_config.multipart_enabled:
-             while not multipart_send_queue.empty() or not multipart_chunk_queue.empty():
+            while not multipart_send_queue.empty() or not multipart_chunk_queue.empty():
                 time.sleep(0.1)
             # send sentinel to all threads
             multipart_exit_event.set()

--- a/skyplane/api/transfer_job.py
+++ b/skyplane/api/transfer_job.py
@@ -341,6 +341,8 @@ class Chunker:
                     yield multipart_chunk_queue.get()
 
         if self.transfer_config.multipart_enabled:
+             while not multipart_send_queue.empty() or not multipart_chunk_queue.empty():
+                time.sleep(0.1)
             # send sentinel to all threads
             multipart_exit_event.set()
             for thread in multipart_chunk_threads:


### PR DESCRIPTION
1、when I transfer a large number of files, the program will miss some of the files.