### PR TITLE
Don't search host directories for private keys when connecting to a cloud instance

### DIFF
--- a/skyplane/compute/aws/aws_server.py
+++ b/skyplane/compute/aws/aws_server.py
@@ -156,6 +156,7 @@ class AWSServer(Server):
             # ssh_username="ec2-user",
             ssh_username=self.login_name,
             ssh_pkey=str(self.local_keyfile),
+            host_pkey_directories=[],
             local_bind_address=("127.0.0.1", 0),
             remote_bind_address=("127.0.0.1", remote_port),
         )

--- a/skyplane/compute/azure/azure_server.py
+++ b/skyplane/compute/azure/azure_server.py
@@ -201,6 +201,7 @@ class AzureServer(Server):
             ssh_username=uname,
             ssh_pkey=str(self.ssh_private_key),
             ssh_private_key_password=ssh_key_password,
+            host_pkey_directories=[],
             local_bind_address=("127.0.0.1", 0),
             remote_bind_address=("127.0.0.1", remote_port),
         )

--- a/skyplane/compute/gcp/gcp_server.py
+++ b/skyplane/compute/gcp/gcp_server.py
@@ -115,6 +115,7 @@ class GCPServer(Server):
             ssh_username=uname,
             ssh_pkey=str(self.ssh_private_key),
             ssh_private_key_password=ssh_key_password,
+            host_pkey_directories=[],
             local_bind_address=("127.0.0.1", 0),
             remote_bind_address=("127.0.0.1", remote_port),
         )

--- a/skyplane/compute/ibmcloud/ibmcloud_server.py
+++ b/skyplane/compute/ibmcloud/ibmcloud_server.py
@@ -96,6 +96,7 @@ class IBMCloudServer(Server):
             # ssh_username="ec2-user",
             ssh_username=self.vsi.ssh_credentials["username"],
             ssh_pkey=str(self.vsi.ssh_credentials["key_filename"]),
+            host_pkey_directories=[],
             local_bind_address=("127.0.0.1", 0),
             remote_bind_address=("127.0.0.1", remote_port),
         )


### PR DESCRIPTION
Don't search host directories for private keys when connecting to a cloud instance
Eliminates noisy logs like:
```
2023-05-07 16:29:09,072| ERROR   | Password is required for key /home/shadaj/.ssh/id_rsa
2023-05-07 16:29:09,827| ERROR   | Password is required for key /home/shadaj/.ssh/id_rsa
2023-05-07 16:29:10,502| ERROR   | Password is required for key /home/shadaj/.ssh/id_rsa
2023-05-07 16:29:11,252| ERROR   | Password is required for key /home/shadaj/.ssh/id_rsa
```
